### PR TITLE
Logic expressions (and/or) break

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -93,6 +93,8 @@ var Compiler = Object.extend({
                         nodes.Filter,
                         nodes.LookupVal,
                         nodes.Compare,
+                        nodes.And,
+                        nodes.Or,
                         nodes.Not);
         this.compile(node, frame);
     },

--- a/tests/test.js
+++ b/tests/test.js
@@ -496,6 +496,18 @@ describe('compiler', function() {
         s = render('{% if not hungry %}good{% endif %}',
                    { hungry: false });
         s.should.equal('good');
+
+        s = render('{% if hungry and like_pizza %}good{% endif %}',
+            { hungry: true, like_pizza: true });
+        s.should.equal('good');
+
+        s = render('{% if hungry or like_pizza %}good{% endif %}',
+            { hungry: false, like_pizza: true });
+        s.should.equal('good');
+
+        s = render('{% if (hungry or like_pizza) and anchovies %}good{% endif %}',
+            { hungry: false, like_pizza: true, anchovies: true });
+        s.should.equal('good');
     });
 
     it('should compile for blocks', function() {


### PR DESCRIPTION
Currently using (and/or) in expressions with throw with "Error: invalid type: And/Or".

Added:
Compiler._compile_expression typechecking now accepts {Or} and {And} nodes
Tests for expressions with and/or
