### PR TITLE
Don't assume mocha is in global path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test: 
-	mocha -b -R tap tests
+	./node_modules/mocha/bin/mocha -b -R tap tests
 
 browserfiles:
 	./bin/bundle browser/nunjucks-dev.js


### PR DESCRIPTION
Let's use the one provided by npm instead.
