### PR TITLE
parseTemplateRef now accepts LookupVal

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -295,7 +295,8 @@ var Parser = Object.extend({
         node.template = this.parsePrimary();
         if(!(node.template instanceof nodes.Literal &&
              lib.isString(node.template.value)) &&
-           !(node.template instanceof nodes.Symbol)) {
+           !(node.template instanceof nodes.Symbol) &&
+           !(node.template instanceof nodes.LookupVal)) {
             this.fail('parseExtends: string or value expected');
         }
 

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -276,6 +276,10 @@ describe('compiler', function() {
         s = render('hello world {% include tmpl %}',
                   { name: 'thedude', tmpl: "include.html" });
         s.should.equal('hello world FooInclude thedude');
+
+        s = render('hello world {% include data.tmpl %}',
+            { name: 'thedude', data: {tmpl: "include.html"} });
+        s.should.equal('hello world FooInclude thedude');
     });
 
     it('should maintain nested scopes', function() {


### PR DESCRIPTION
Fixes lookupval include tag issue in #7
