### PR TITLE
Fix - give methods proper scope

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -261,12 +261,11 @@ var Compiler = Object.extend({
     },
 
     compileLookupVal: function(node, frame) {
-        this.emit('runtime.suppressValue(((');
+        this.emit('runtime.suppressLookupValue((');
         this._compileExpression(node.target, frame);
-        this.emit(')||{})');
-        this.emit('[');
+        this.emit('),');
         this._compileExpression(node.val, frame);
-        this.emit('])');
+        this.emit(')');
     },
 
     compileFunCall: function(node, frame) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -113,6 +113,16 @@ function suppressValue(val) {
     return (val !== undefined && val !== null) ? val : "";
 }
 
+function suppressLookupValue(obj, val) {
+    obj = obj || {};
+    val = obj[val];
+
+    return (typeof val === 'function') ?
+        function() {
+            return suppressValue(val.apply(obj, arguments))} :
+        suppressValue(val);
+}
+
 function contextOrFrameLookup(context, frame, name) {
     var val = context.lookup(name);
     return (val !== undefined && val !== null) ?
@@ -126,5 +136,6 @@ module.exports = {
     makeKeywordArgs: makeKeywordArgs,
     numArgs: numArgs,
     suppressValue: suppressValue,
+    suppressLookupValue: suppressLookupValue,
     contextOrFrameLookup: contextOrFrameLookup
 };

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -58,6 +58,12 @@ describe('compiler', function() {
         s.should.equal('msghi');
     });
 
+    it('should compile function calls with correct scope', function() {
+        var s = render('{{ foo.bar() }}',
+            { foo: { bar: function() { return this.baz }, baz: 'hello' }});
+        s.should.equal('hello');
+    });
+
     it('should compile if blocks', function() {
         var tmpl = ('Give me some {% if hungry %}pizza' +
                     '{% else %}water{% endif %}');


### PR DESCRIPTION
This fixes #35 and #36.

Quick rundown -- 

Scope in javascript is unbound (determined by syntax, not by definition). With the addition of suppressing undefined values, an example `{{ form.as_div() }}` output was affected like so:

```
(suppress(((form) || {})["as_div"]))()
```

which was losing the scope as it was not being called on an object. This patch adds a binding mechanism for lookups that calls the methods with the intended scope.
