### PR TITLE
Prevent loading templates out of the search paths

### DIFF
--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs');
 var path = require('path');
 var lib = require('./lib');
@@ -23,7 +22,7 @@ var FileSystemLoader = Object.extend({
 
         for(var i=0; i<paths.length; i++) {
             var p = path.join(paths[i], name);
-            if(existsSync(p)) {
+            if(p.indexOf(paths[i]) === 0 && existsSync(p)) {
                 fullpath = p;
                 break;
             }


### PR DESCRIPTION
This check prevents someone to use a relative path to a template in a directory outside the search paths. For example: "../../something/bad.html".

I am using nunjucks in a web service where users can edit their own templates and of course I don't want to let them to find a system file or use a template of another user.
