### PR TITLE
No more 'string is not a function' errors

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -131,6 +131,13 @@ function suppressLookupValue(obj, val) {
     }
 }
 
+function callWrap(obj, name, args) {
+    if (obj) {
+        return obj.apply(this, args);
+    }
+    throw new Error('Could not find value "' + name + '" to call.');
+}
+
 function contextOrFrameLookup(context, frame, name) {
     var val = context.lookup(name);
     return (val !== undefined && val !== null) ?
@@ -155,6 +162,7 @@ module.exports = {
     suppressValue: suppressValue,
     suppressLookupValue: suppressLookupValue,
     contextOrFrameLookup: contextOrFrameLookup,
+    callWrap: callWrap,
     handleError: handleError,
     isArray: lib.isArray
 };

--- a/tests/runtime.js
+++ b/tests/runtime.js
@@ -1,0 +1,36 @@
+var should = require('should');
+var render = require('./util').render;
+
+
+describe('runtime', function() {
+    it('should report the failed function calls to symbols', function() {
+        (function() {render(
+            '{{ foo("cvan") }}'
+        )}).should.throw(/Could not find value "foo" to call./);
+    });
+
+    it('should report the failed function calls to lookups', function() {
+        (function() {render(
+            '{{ foo["bar"]("cvan") }}'
+        )}).should.throw(/foo\["bar"\]/);
+    });
+
+    it('should report the failed function calls to calls', function() {
+        (function() {render(
+            '{{ foo.bar("second call") }}'
+        )}).should.throw(/foo\["bar"\]/);
+    });
+
+    it('should report the failed function calls w/multiple args', function() {
+        (function() {render(
+            '{{ foo.bar("multiple", "args") }}'
+        )}).should.throw(/foo\["bar"\]/);
+    });
+
+    it('should report the failed function calls to filters', function() {
+        (function() {render(
+            '{{ foo["bar"]["zip"]("multiple", "args") }}'
+        )}).should.throw(/foo\["bar"\]\["zip"\]/);
+    });
+
+});


### PR DESCRIPTION
This introduces a wrapper around function calls that passes in a statically determined name for the object that was attempted to be called. If the object doesn't resolve before we try to evaluate it, we throw a friendly error.
