### PR TITLE
Truncate filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -312,6 +312,22 @@ var filters = {
         return str.replace(/^\s*|\s*$/g, '');
     },
 
+    truncate: function(input, length, killwords, end) {
+        length = length || 255;
+
+        if (input.length <= length)
+            return input;
+
+        if (killwords) {
+            input = input.substring(0, length);
+        } else {
+            input = input.substring(0, input.lastIndexOf(' ', length));
+        }
+
+        input += (end !== undefined && end !== null) ? end : '...';
+        return input;
+    },
+
     upper: function(str) {
         return str.toUpperCase();
     },

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -276,6 +276,23 @@ describe('filter', function() {
         s.should.equal('foo');
     });
 
+    it('truncate', function() {
+        var s = render('{{ "foo bar" | truncate(3) }}');
+        s.should.equal('foo...');
+
+        var s = render('{{ "foo bar baz" | truncate(6) }}');
+        s.should.equal('foo...');
+
+        var s = render('{{ "foo bar baz" | truncate(7) }}');
+        s.should.equal('foo bar...');
+
+        var s = render('{{ "foo bar baz" | truncate(5, true) }}');
+        s.should.equal('foo b...');
+
+        var s = render('{{ "foo bar baz" | truncate(6, true, "?") }}');
+        s.should.equal('foo ba?');
+    });
+
     it('upper', function() {
         var s = render('{{ "foo" | upper }}');
         s.should.equal('FOO');


### PR DESCRIPTION
Args are the same as jinja2: `(input, length, killwords, end)`

`length` defaults to 255.

`killwords` (default: `false`) -- if `true`, will not try to split on words. If `false`, it will split on words and it will try to save the last word.

`end` (default: `...`) -- If `input` is truncated, append this string to the end.

Note: `length` does not account for the length of `end`.
