### PR TITLE
Restore suppressValue to memberLookup

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,4 +1,3 @@
-
 var lib = require('./lib');
 var Object = require('./object');
 
@@ -170,7 +169,7 @@ function suppressValue(val, autoescape) {
     return val;
 }
 
-function memberLookup(obj, val) {
+function memberLookup(obj, val, autoescape) {
     obj = obj || {};
 
     if(typeof obj[val] === 'function') {
@@ -179,7 +178,7 @@ function memberLookup(obj, val) {
         };
     }
 
-    return obj[val];
+    return suppressValue(obj[val], autoescape);
 }
 
 function callWrap(obj, name, args) {


### PR DESCRIPTION
Consider the following code:

``` django
{% for i in foo.bar %} {% endfor %}
```

if `foo` is defined as `{}` in the current context. The produced code would be something like:

``` js
var t_1 = runtime.memberLookup((l_foo),"bar", env.autoesc);
for(var t_2=0; t_2 < t_1.length; t_1++) {
// ...
}
```

`t_1` would otherwise contain `undefined`, meaning that `t_1.length` would throw an exception.
