### PR TITLE
Should render nested blocks defined in inheriting templates

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -844,6 +844,7 @@ var Compiler = Object.extend({
         }
         this.emitFuncEnd(this.isChild);
 
+        this.isChild = false;
         var blocks = node.findAll(nodes.Block);
         for(var i=0; i<blocks.length; i++) {
             var block = blocks[i];

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -294,6 +294,23 @@ describe('compiler', function() {
         s.should.equal('start: end: bazstart: bazend: bazfinal: ');
     });
 
+    it('should render nested blocks defined in inheriting template', function() {
+        var s = render('{% extends "base.html" %}' +
+            '{% block block1 %}{% block nested %}BAR{% endblock %}{% endblock %}');
+        s.should.equal('FooBARBazFizzle');
+    });
+
+    it('should inherit templates but not needlessly compile child templates', function() {
+        var count = 0;
+        render('{% extends "base.html" %}' +
+            '{% block block1 %}{{ foo() }}{% endblock %}', {
+            foo: function(){
+                count++;
+            }
+        });
+        count.should.equal(1);
+    });
+
     it('should inherit templates', function() {
         var s = render('{% extends "base.html" %}');
         s.should.equal('FooBarBazFizzle');


### PR DESCRIPTION
This is a fix for #74 
not sure that this is the right way to do it, but it seems to fix the issue. i added 2 testcases. One that captures this fix, and another that captures a bug that 10ac70f4570dea02739bb92c02423b00554d27ab addressed (though not the same bug as in #61)
