### PR TITLE
Add IE8 support to nunjucks (rebased)

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -222,7 +222,7 @@ var Context = Object.extend({
     },
 
     getSuper: function(env, name, block, frame, runtime) {
-        var idx = (this.blocks[name] || []).indexOf(block);
+        var idx = lib.indexOf(this.blocks[name] || [], block);
         var blk = this.blocks[name][idx + 1];
         var context = this;
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -35,7 +35,7 @@ var filters = {
 
     capitalize: function(str) {
         var ret = str.toLowerCase();
-        return r.copySafeness(str, ret[0].toUpperCase() + ret.slice(1));
+        return r.copySafeness(str, ret.charAt(0).toUpperCase() + ret.slice(1));
     },
 
     center: function(str, width) {

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1,3 +1,4 @@
+var lib = require('./lib');
 
 var whitespaceChars = " \n\t\r";
 var delimChars = "()[]{}%*-+/#,:|.<>=!";
@@ -97,7 +98,7 @@ Tokenizer.prototype.nextToken = function() {
             var curComplex = cur + this.current();
             var type;
 
-            if(complexOps.indexOf(curComplex) != -1) {
+            if(lib.indexOf(complexOps, curComplex) != -1) {
                 this.forward();
                 cur = curComplex;
             }
@@ -147,10 +148,10 @@ Tokenizer.prototype.nextToken = function() {
         // Parse out the template text, breaking on tag
         // delimiters because we need to look for block/variable start
         // tags (don't use the full delimChars for optimization)
-        var beginChars = (BLOCK_START[0] +
-                          VARIABLE_START[0] +
-                          COMMENT_START[0] +
-                          COMMENT_END[0]);
+        var beginChars = (BLOCK_START.charAt(0) +
+                          VARIABLE_START.charAt(0) +
+                          COMMENT_START.charAt(0) +
+                          COMMENT_END.charAt(0));
         var tok;
 
         if(this.is_finished()) {
@@ -364,13 +365,13 @@ Tokenizer.prototype.back = function() {
 
 Tokenizer.prototype.current = function() {
     if(!this.is_finished()) {
-        return this.str[this.index];
+        return this.str.charAt(this.index);
     }
     return "";
 };
 
 Tokenizer.prototype.previous = function() {
-    return this.str[this.index-1];
+    return this.str.charAt(this.index-1);
 };
 
 module.exports = {

--- a/src/lib.js
+++ b/src/lib.js
@@ -118,6 +118,36 @@ exports.toArray = function(obj) {
     return Array.prototype.slice.call(obj);
 };
 
+exports.indexOf = function(array, searchElement /*, fromIndex */) {
+    if (array == null) {
+        throw new TypeError();
+    }
+    var t = Object(array);
+    var len = t.length >>> 0;
+    if (len === 0) {
+        return -1;
+    }
+    var n = 0;
+    if (arguments.length > 2) {
+        n = Number(arguments[2]);
+        if (n != n) { // shortcut for verifying if it's NaN
+            n = 0;
+        } else if (n != 0 && n != Infinity && n != -Infinity) {
+            n = (n > 0 || -1) * Math.floor(Math.abs(n));
+        }
+    }
+    if (n >= len) {
+        return -1;
+    }
+    var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
+    for (; k < len; k++) {
+        if (k in t && t[k] === searchElement) {
+            return k;
+        }
+    }
+    return -1;
+};
+
 exports.without = function(array) {
     var result = [];
     if (!array) {

--- a/src/object.js
+++ b/src/object.js
@@ -2,7 +2,10 @@
 // A simple class system, more documentation to come
 
 function extend(cls, name, props) {
-    var prototype = Object.create(cls.prototype);
+    var F = function() {};
+    F.prototype = cls.prototype;
+
+    var prototype = new F();
     var fnTest = /xyz/.test(function(){ xyz; }) ? /\bparent\b/ : /.*/;
     props = props || {};
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -413,7 +413,7 @@ var Parser = Object.extend({
         }
 
         if(this.breakOnBlocks &&
-           this.breakOnBlocks.indexOf(tok.value) != -1) {
+           lib.indexOf(this.breakOnBlocks, tok.value) != -1) {
             return null;
         }
 
@@ -432,7 +432,7 @@ var Parser = Object.extend({
             if (this.extensions.length) {
                 for (var i = 0; i < this.extensions.length; i++) {
                     var ext = this.extensions[i];
-                    if ((ext.tags || []).indexOf(tok.value) > -1) {
+                    if (lib.indexOf(ext.tags || [], tok.value) > -1) {
                         return ext.parse(this, nodes, lexer);
                     }
                 }
@@ -620,7 +620,7 @@ var Parser = Object.extend({
             if(!tok) {
                 break;
             }
-            else if(compareOps.indexOf(tok.value) != -1) {
+            else if(lib.indexOf(compareOps, tok.value) != -1) {
                 ops.push(new nodes.CompareOperand(tok.lineno,
                                                   tok.colno,
                                                   this.parseAdd(),

--- a/src/web-loaders.js
+++ b/src/web-loaders.js
@@ -3,8 +3,11 @@ var Object = require('./object');
 
 var HttpLoader = Object.extend({
     init: function(baseURL, neverUpdate) {
-        console.log("[nunjucks] Warning: only use HttpLoader in " +
-                    "development. Otherwise precompile your templates.");
+        if (typeof(console) !== "undefined" && console.log &&
+            typeof(nunjucks) == "object" && !nunjucks.testing) {
+          console.log("[nunjucks] Warning: only use HttpLoader in " +
+                      "development. Otherwise precompile your templates.");
+        }
         this.baseURL = baseURL || '';
         this.neverUpdate = neverUpdate;
     },
@@ -33,7 +36,8 @@ var HttpLoader = Object.extend({
             }
         };
 
-        url += (url.indexOf('?') === -1 ? '?' : '&') + 's=' + Date.now();
+        url += (url.indexOf('?') === -1 ? '?' : '&') + 's=' + 
+               (new Date().getTime());
 
         // Synchronous because this API shouldn't be used in
         // production (pre-load compiled templates instead)

--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -24,6 +24,7 @@
   <script src="../globals.js"></script>
 
   <script>
+    nunjucks.testing = true;
     mocha.checkLeaks();
     mocha.run();
   </script>

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -95,7 +95,10 @@
         }
 
         var type = ast[0];
-        var dummy = Object.create(type.prototype);
+        var F = function() {};
+        F.prototype = type.prototype;
+
+        var dummy = new F();
 
         if(dummy instanceof nodes.NodeList) {
             return new type(0, 0, lib.map(ast.slice(1), toNodes));


### PR DESCRIPTION
This is a rebase of #75.

In general, the fixes amount to dealing with IE8's lack of `Array.indexOf()`, `Object.create()`, `Date.now()`, and string indexing via array notation.
