### PR TITLE
Fix for loops getting falsey (but not undefined) values

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -502,7 +502,7 @@ var Compiler = Object.extend({
             });
         });
 
-        this.emit('if(' + arr + ' !== undefined) {');
+        this.emit('if(' + arr + ') {');
 
         if(node.name instanceof nodes.Array) {
             // key/value iteration. the user could have passed a dict

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -193,6 +193,9 @@
 
             s = render('{% for i in foo.bar %}{{ i }}{% endfor %}', { foo: {} });
             expect(s).to.be('');
+
+            s = render('{% for i in foo %}{{ i }}{% endfor %}', { foo: null });
+            expect(s).to.be('');
         });
 
         it('should compile operators', function() {


### PR DESCRIPTION
This brought down marketplace-dev for about twenty minutes today. More interestingly, it only affects Firefox.
