### PR TITLE
Context filters

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -113,7 +113,9 @@ var Compiler = Object.extend({
     },
 
     _compileAggregate: function(node, frame, startChar, endChar) {
-        this.emit(startChar);
+        if(startChar) {
+            this.emit(startChar);
+        }
 
         for(var i=0; i<node.children.length; i++) {
             if(i > 0) {
@@ -123,7 +125,9 @@ var Compiler = Object.extend({
             this.compile(node.children[i], frame);
         }
 
-        this.emit(endChar);
+        if(endChar) {
+            this.emit(endChar);
+        }
     },
 
     _compileExpression: function(node, frame) {
@@ -406,8 +410,9 @@ var Compiler = Object.extend({
         var name = node.name;
         this.assertType(name, nodes.Symbol);
 
-        this.emit('env.getFilter("' + name.value + '")');
-        this._compileAggregate(node.args, frame, '(', ')');
+        this.emit('env.getFilter("' + name.value + '").call(context, ');
+        this._compileAggregate(node.args, frame);
+        this.emit(')');
     },
 
     compileKeywordArgs: function(node, frame) {
@@ -897,7 +902,7 @@ var Compiler = Object.extend({
 // var fs = require("fs");
 //var src = '{{ foo({a:1}) }} {% block content %}foo{% endblock %}';
 // var c = new Compiler();
-// var src = '{% extends "b.html" %}{% block block1 %}{% block nested %}BAR{% endblock %}{% endblock %}';
+// var src = '{{ foo | poop(1, 2, 3) }}';
 //var extensions = [new testExtension()];
 
 // var ns = parser.parse(src);

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1,13 +1,17 @@
 (function() {
-    var expect, render;
+    var expect, render, Environment, Template;
 
     if(typeof require != 'undefined') {
         expect = require('expect.js');
         render = require('./util').render;
+        Environment = require('../src/environment').Environment;
+        Template = require('../src/environment').Template;
     }
     else {
         expect = window.expect;
         render = window.render;
+        Environment = nunjucks.Environment;
+        Template = nunjucks.Template;
     }
 
     describe('compiler', function() {
@@ -636,6 +640,14 @@
               { autoescape: true }
             );
             expect(s).to.be('<b>Foo</b>');
+        });
+
+        it('should pass context as this to filters', function() {
+            var e = new Environment();
+            e.addFilter('hallo', function(foo) { return foo + this.lookup('bar'); });
+
+            var t = new Template('{{ foo | hallo }}', e);
+            expect(t.render({ foo: 1, bar: 2 })).to.be('3');
         });
     });
 })();


### PR DESCRIPTION
This makes "this" reference the context object in all filters. The performance hit is negligible, only incurring an additional `.call()`.
