### PR TITLE
Fix for issue #114

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -502,7 +502,6 @@ var Compiler = Object.extend({
 
             if (id === null) {
                 id = this.tmpid();
-                frame.set(name, id);
 
                 // Note: This relies on js allowing scope across
                 // blocks, in case this is created inside an `if`
@@ -521,6 +520,9 @@ var Compiler = Object.extend({
             var name = target.value;
 
             this.emitLine('frame.set("' + name + '", ' + id + ');');
+            if (frame.get(name) === null) {
+                frame.set(name, id);
+            }
 
             // We are running this for every var, but it's very
             // uncommon to assign to multiple vars anyway

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -549,6 +549,10 @@
                   { foo: 'bar' },
                   'bar');
 
+            equal('{% set username = username + "pasta" %}{{ username }}',
+                  { username: 'basta' },
+                  'bastapasta');
+
             finish(done);
         });
 


### PR DESCRIPTION
This prevents the compiler from thinking that it has a reference to
any variable before it's actually output the assignment for said var.
