### PR TITLE
More succinct random filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -184,12 +184,7 @@ var filters = {
     },
 
     random: function(arr) {
-        var i = Math.floor(Math.random() * arr.length);
-        if(i == arr.length) {
-            i--;
-        }
-
-        return arr[i];
+        return arr[Math.floor(Math.random() * arr.length)];
     },
 
     replace: function(str, old, new_, maxCount) {


### PR DESCRIPTION
`Math.random()` should never produce a floating point number with a high enough precision to cause rounding errors when multiplying by a normal JS integer, and it will never produce `1.0` as an output.

Not a big win, but a bit cleaner and less code.
