### PR TITLE
Reverse order of context/frame lookup (issue #119)

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -220,10 +220,10 @@ function callWrap(obj, name, args) {
 }
 
 function contextOrFrameLookup(context, frame, name) {
-    var val = context.lookup(name);
+    var val = frame.lookup(name);
     return (val !== undefined && val !== null) ?
         val :
-        frame.lookup(name);
+        context.lookup(name);
 }
 
 function handleError(error, lineno, colno) {

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -194,6 +194,21 @@
             equal('{% ' + block + ' k, v in items %}{{ loop.length }}{% ' + end + ' %}',
                   { items: { foo: 1, bar: 2 }},
                   '22');
+
+            render('{% set item = passed_var %}' +
+                   '{% include "item.html" %}\n' +
+                   '{% ' + block + ' i in passed_iter %}' +
+                     '{% set item = i %}' +
+                     '{% include "item.html" %}\n' +
+                   '{% ' + end + ' %}',
+                   {
+                     passed_var: 'test',
+                     passed_iter: ['1', '2', '3']
+                   },
+                   {},
+                   function(err, res) {
+                       expect(res).to.be('showing test\nshowing 1\nshowing 2\nshowing 3\n');
+                   });
         }
 
         it('should compile for blocks', function(done) {


### PR DESCRIPTION
I don't know if there's any particular reason why `contextOrFrameLookup` looks at `context` first, but I think this has been the cause of a lot of heartache surrounding the `{% set %}` block and also macro arguments. If something in the frame overrides something in the context, the context was still being trusted.

The tests pass for me, as well, which I found both pleasant and surprising.
