### PR TITLE
Adds '.jinja' file extension to precompilation process

### DIFF
--- a/src/precompile.js
+++ b/src/precompile.js
@@ -56,7 +56,7 @@ function precompile(inputPath, env, force) {
                 if(stat && stat.isDirectory()) {
                     addTemplates(filepath);
                 }
-                else if(path.extname(filepath) == '.html') {
+                else if(['.html', '.jinja'].indexOf(path.extname(filepath)) !== -1) {
                     templates.push(filepath);
                 }
             }


### PR DESCRIPTION
When using Jinja & Django, it is common to use a `.jinja` file extension to clearly indicate that we are not using the default template engine. Since Nunjucks is very close to jinja, it would be nice to also detect this file extension (very useful for shared templates).
