### PR TITLE
Update node-loader.js to fix Windows compatibility with node 0.10.x

### DIFF
--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -25,7 +25,7 @@ var FileSystemLoader = Loader.extend({
             lib.each(this.searchPaths, function(p) {
                 if(existsSync(p)) {
                     fs.watch(p, { persistent: false }, function(event, filename) {
-                        var fullname = path.join(p, filename);
+                        var fullname = path.join(p, filename || '');
                         if(event == 'change' && fullname in this.pathsToNames) {
                             this.emit('update', this.pathsToNames[fullname]);
                         }


### PR DESCRIPTION
According to [the nodemon issue tracker](https://github.com/remy/nodemon/issues/150), there is an error thrown by path.join on Windows/Node 0.10.x which is : 

_src/node-loaders.js:28:45_

> TypeError: Arguments to path.join must be strings

The issue can be easily fixed by changing `path.join(dir, filename)` to `path.join(dir, filename || '')`.
I tested it and it actually works, the watcher doesn't throw an error anymore while watching templates on Windows/Node 0.10.x.
