### PR TITLE
Added test and proposed fix for simple loader

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -58,9 +58,11 @@ var Environment = Obj.extend({
         var cache = {};
 
         lib.each(this.loaders, function(loader) {
-            loader.on('update', function(template) {
-                cache[template] = null;
-            });
+            if(typeof loader.on === 'function'){
+                loader.on('update', function(template) {
+                    cache[template] = null;
+                });
+            }
         });
 
         this.cache = cache;

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -1,0 +1,34 @@
+(function() {
+    var expect, Environment, Loader, templatesPath;
+
+    if(typeof require != 'undefined') {
+        expect = require('expect.js');
+        Environment = require('../src/environment').Environment;
+        templatesPath = 'tests/templates';
+    }
+    else {
+        expect = window.expect;
+        Environment = nunjucks.Environment;
+        Loader = nunjucks.WebLoader;
+        templatesPath = '../templates';
+    }
+
+    describe('loader', function() {
+        it('should allow a simple loader to be created', function() {
+            // From Docs: http://jlongster.github.io/nunjucks/api.html#writing-a-loader
+            // We should be able to create a loader that only exposes getSource
+            function MyLoader(opts) {
+                // configuration
+            }
+
+            MyLoader.prototype.getSource = function(name) {
+                return { src: "Hello World",
+                            path: "/tmp/somewhere" };
+            };
+
+            var env = new Environment(new MyLoader(templatesPath));
+            var parent = env.getTemplate('fake.html');
+            expect(parent.render()).to.be('Hello World');
+        });
+    });
+})();


### PR DESCRIPTION
Currently, the docs state that you can write a simple loader by presenting an object that implements getSource() only (http://jlongster.github.io/nunjucks/api.html#writing-a-loader).

Doing so will currently fail, as the caching code attempts to call on() on all loaders.
