### PR TITLE
Can't pass array to configure as first argument

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -100,7 +100,7 @@ exports.isString = function(obj) {
 };
 
 exports.isObject = function(obj) {
-    return obj === Object(obj);
+    return ObjProto.toString.call(obj) == '[object Object]';
 };
 
 exports.groupBy = function(obj, val) {


### PR DESCRIPTION
I use `.configure` to get environment, and pass two different path. I think it should work that pass to `FileSystemLoader`, but it didn't.

```
nunjucks.configure(['views', 'widgets']);
```

Is something wrong with `isObject`, I think it should be

```
exports.isObject = function(obj) {
    return ObjProto.toString.call(obj) === '[object Object]'
};
```
