### PR TITLE
Added a filter absolutize to create absolute urls out of relative or absolute urls

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -1,10 +1,15 @@
 
 var lib = require('./lib');
 var r = require('./runtime');
+url = require('url');
 
 var filters = {
     abs: function(n) {
         return Math.abs(n);
+    },
+
+    absolutize: function(str, base) {
+        return url.resolve(base, str);
     },
 
     batch: function(arr, linecount, fill_with) {

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -23,6 +23,12 @@
             finish(done);
         });
 
+        it('absolutize', function(done) {
+            equal('{{"/examples"|absolutize("http://example.com")}}', 'http://example.com/examples');
+            equal('{{"http://anotherexample.com/stuff"|absolutize("http://example.com")}}', 'http://anotherexample.com/stuff');
+            finish(done);
+        });
+
         it('batch', function(done) {
             equal('{% for a in [1,2,3,4,5,6]|batch(2) %}' +
                   '-{% for b in a %}' +


### PR DESCRIPTION
I have a variable that sometimes contains a relative and sometimes an absolute URL. But for the og:image I want an absolute URL.
So I wrote a short filter for that. It takes a base to prepend to relative urls and leave absolute ones untouched.
Uses the standard functionality present in node.url.
