### PR TITLE
extension have an option that can ignore escape

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -211,9 +211,8 @@ var Compiler = Object.extend({
     compileCallExtension: function(node, frame, async) {
         var name = node.extName;
         var args = node.args;
-        var opt = node.opt;
         var contentArgs = node.contentArgs;
-        var autoescape = typeof opt.autoescape === 'boolean' ? opt.autoescape : true;
+        var autoescape = typeof node.autoescape === 'boolean' ? node.autoescape : true;
         var transformedArgs = [];
 
         if(!async) {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -152,7 +152,7 @@ var CallExtension = Node.extend("CallExtension", {
         this.prop = prop;
         this.args = args || new NodeList();
         this.contentArgs = contentArgs || [];
-        this.opt = ext.opt || {};
+        this.autoescape = ext.autoescape;
     }
 });
 

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -847,9 +847,7 @@
             function testExtension() {
                 this.tags = ['test'];
 
-                this.opt = {
-                    autoescape: false
-                };
+                this.autoescape = false;
 
                 this.parse = function(parser, nodes) {
                     var tok = parser.nextToken();
@@ -874,7 +872,6 @@
                 null,
                 opts,
                 function(err, res) {
-                    console.log(res)
                     expect(res).to.be('<b>Foo</b>');
                 }
             );


### PR DESCRIPTION
This PR is based on https://github.com/jlongster/nunjucks/issues/190, it's my attempt to resolve this problem.

Extension have an option `autoescape`, and have a priority over env. if it's set false, extension will not escape, otherwise will.

I give extension an `opt` property that can be used by other purpose in the future.
