### PR TITLE
add browser key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "optimist": "*",
         "chokidar": "git://github.com/appleifreak/chokidar.git"
     },
+    "browser" : "./browser/nunjucks.js",
     "devDependencies": {
         "expect.js": "*",
         "mocha": "*",


### PR DESCRIPTION
Hello James,

God we love nunjucks. Too cool. Trying to get everything working smoothly with [parcelify](https://github.com/rotundasoftware/parcelify). Developing [a transform stream](https://github.com/rotundasoftware/nunjucksify) to precompile templates and trying to make the compiled templates global-free (relying on the browserify requires for the nunjucks object and also template depedencies). We are almost there but browerify grabs the server side version on `require( 'nunjucks' )` due to the lack of ["browser" field](https://github.com/substack/node-browserify#browser-field) in package json. This fixes.

Thank you very a great library.

David
