### PR TITLE
Fix for available loaders in node-webkit

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -1,4 +1,4 @@
-if(typeof window === 'undefined') {
+if(typeof window === 'undefined' || window !== this) {
     module.exports = require('./node-loaders');
 }
 else {


### PR DESCRIPTION
Making the environment check in loaders.js more specific to account for environments that have both node and browser like features (like node-webkit).
