### PR TITLE
expose name option on precompile script

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -6,7 +6,7 @@ var lib = require('../src/lib');
 
 var optimist = require('optimist')
 
-    .usage('$0 [-f|--force] [-a|--filters <filters>] [-i|--include <regex>] [-x|--exclude <regex>] <path>')
+    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] <path>')
     .wrap(80)
 
     .describe('help', 'Display this help message')
@@ -21,6 +21,10 @@ var optimist = require('optimist')
     .describe('filters', 'Give the compiler a comma-delimited list of asynchronous filters, required for correctly generating code')
         .string('filters')
         .alias('a', 'filters')
+
+    .describe('name', 'Specify the template name when compiling a single file')
+        .string('name')
+        .alias('n', 'n')
 
     .describe('include', 'Include a file or folder which match the regex but would otherwise be excluded. You can use this flag multiple times')
         .string('include' )
@@ -51,6 +55,7 @@ console.log(precompile(argv._[0], {
 
     env : env,
     force : argv.force,
+    name : argv.name,
 
     include : [].concat(argv.include),
     exclude : [].concat(argv.exclude)


### PR DESCRIPTION
I'm using a makefile to precompile templates to be used on the client side.  In order to do so I needed to be able to change the path from the source file name to match the relative public url where the template can be downloaded.  Fortunately it was just a matter of exposing the option to the CLI.
