### PR TITLE
add module.exports

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -48,6 +48,7 @@ if(typeof define === 'function' && define.amd) {
 }
 else {
     window.nunjucks = nunjucks;
+    if(typeof module !== 'undefined') module.exports = nunjucks;
 }
 " >> "$output"
 


### PR DESCRIPTION
Only one small additional change needed to get nunjucks runtime working with [browserify](http://browserify.org/), [cartero](https://github.com/rotundasoftware/cartero), etc. Here it is...
