### PR TITLE
Array.prototype.indexOf polyfill is incorrect

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -270,7 +270,7 @@ var Context = Obj.extend({
     },
 
     getSuper: function(env, name, block, frame, runtime, cb) {
-        var idx = (this.blocks[name] || []).indexOf(block);
+        var idx = lib.indexOf(this.blocks[name] || [], block);
         var blk = this.blocks[name][idx + 1];
         var context = this;
 

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -98,7 +98,7 @@ Tokenizer.prototype.nextToken = function() {
             var curComplex = cur + this.current();
             var type;
 
-            if(complexOps.indexOf(curComplex) !== -1) {
+            if(lib.indexOf(complexOps, curComplex) !== -1) {
                 this.forward();
                 cur = curComplex;
             }

--- a/src/lib.js
+++ b/src/lib.js
@@ -130,7 +130,7 @@ exports.without = function(array) {
     contains = exports.toArray(arguments).slice(1);
 
     while(++index < length) {
-        if(contains.indexOf(array[index]) === -1) {
+        if(exports.indexOf(contains, array[index]) === -1) {
             result.push(array[index]);
         }
     }
@@ -226,12 +226,11 @@ exports.asyncFor = function(obj, iter, cb) {
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#Polyfill
-if(!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function (searchElement, fromIndex) {
-        if(this === undefined || this === null) {
-            throw new TypeError('"this" is null or not defined');
-        }
-
+exports.indexOf = Array.prototype.indexOf ?
+    function (arr, searchElement, fromIndex) {
+        return Array.prototype.indexOf.call(arr, searchElement, fromIndex);
+    } :
+    function (arr, searchElement, fromIndex) {
         var length = this.length >>> 0; // Hack to convert object.length to a UInt32
 
         fromIndex = +fromIndex || 0;
@@ -248,14 +247,13 @@ if(!Array.prototype.indexOf) {
         }
 
         for(;fromIndex < length; fromIndex++) {
-            if (this[fromIndex] === searchElement) {
+            if (arr[fromIndex] === searchElement) {
                 return fromIndex;
             }
         }
 
         return -1;
     };
-}
 
 if(!Array.prototype.map) {
     Array.prototype.map = function() {

--- a/src/parser.js
+++ b/src/parser.js
@@ -432,7 +432,7 @@ var Parser = Object.extend({
         }
 
         if(this.breakOnBlocks &&
-           this.breakOnBlocks.indexOf(tok.value) !== -1) {
+           lib.indexOf(this.breakOnBlocks, tok.value) !== -1) {
             return null;
         }
 
@@ -456,7 +456,7 @@ var Parser = Object.extend({
             if (this.extensions.length) {
                 for (var i = 0; i < this.extensions.length; i++) {
                     var ext = this.extensions[i];
-                    if ((ext.tags || []).indexOf(tok.value) !== -1) {
+                    if (lib.indexOf(ext.tags || [], tok.value) !== -1) {
                         return ext.parse(this, nodes, lexer);
                     }
                 }
@@ -647,7 +647,7 @@ var Parser = Object.extend({
             if(!tok) {
                 break;
             }
-            else if(compareOps.indexOf(tok.value) !== -1) {
+            else if(lib.indexOf(compareOps, tok.value) !== -1) {
                 ops.push(new nodes.CompareOperand(tok.lineno,
                                                   tok.colno,
                                                   this.parseAdd(),

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,4 +1,5 @@
 var nodes = require('./nodes');
+var lib = require('./lib');
 
 var sym = 0;
 function gensym() {
@@ -93,7 +94,7 @@ function _liftFilters(node, asyncFilters, prop) {
             return node;
         }
         else if((node instanceof nodes.Filter &&
-                 asyncFilters.indexOf(node.name.value) !== -1) ||
+                 lib.indexOf(asyncFilters, node.name.value) !== -1) ||
                 node instanceof nodes.CallExtensionAsync) {
             var symbol = new nodes.Symbol(node.lineno,
                                           node.colno,


### PR DESCRIPTION
Current `Array.prototype.indexOf` polyfill is incorrect. Our code broke in ie8 because our polyfill came after nunjucks. I replaced it with the one from MDN (with fixed coding-style).

But I believe that it's a bad idea to add this polyfill as it's not what nunjucks is made for. Would you accept a pull request where all `indexOf`'s are replaced with `lib.indexOf`?
