### PR TITLE
Express: add view engine support (view without extension).

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "devDependencies": {
         "expect.js": "*",
         "mocha": "*",
-        "uglify-js": "*"
+        "uglify-js": "*",
+        "express": "4.x",
+        "supertest": "*"
     },
     "engines": {
         "node": "*"

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var lib = require('./lib');
 var Obj = require('./object');
 var lexer = require('./lexer');
@@ -179,8 +180,12 @@ var Environment = Obj.extend({
         var env = this;
 
         function NunjucksView(name, opts) {
-            this.name = name;
-            this.path = name;
+            this.name          = name;
+            this.path          = name;
+            this.defaultEngine = opts.defaultEngine;
+            this.ext           = path.extname(name);
+            if (!this.ext && !this.defaultEngine) throw new Error('No default engine was specified and no extension was provided.');
+            if (!this.ext) this.name += (this.ext = ('.' !== this.defaultEngine[0] ? '.' : '') + this.defaultEngine);
         }
 
         NunjucksView.prototype.render = function(opts, cb) {

--- a/tests/express/express.js
+++ b/tests/express/express.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var path     = require('path');
+var express  = require('express');
+var request  = require('supertest');
+var nunjucks = require('../../');
+
+var VIEWS = path.join(__dirname, '..', 'express-sample', 'views');
+
+describe('express', function() {
+
+    var app;
+    var env;
+
+    beforeEach(function() {
+        app = express();
+        env = new nunjucks.Environment(new nunjucks.FileSystemLoader(VIEWS));
+        env.express(app);
+    });
+
+    it('should render a view with extension', function(done) {
+        app.get('/', function(req, res) { res.render('about.html'); });
+        request(app)
+            .get('/')
+            .expect(/This is just the about page/)
+            .end(done);
+    });
+
+    it('should render a view without extension', function(done) {
+        app.get('/', function(req, res) { res.render('about'); });
+        app.set('view engine', 'html');
+        request(app)
+            .get('/')
+            .expect(/This is just the about page/)
+            .end(done);
+    });
+});


### PR DESCRIPTION
This PR is an attempt to fix #214 (Express `View` compatibility).

To render views without extension, we must set `view engine` setting: 

``` js
app.set('view engine', 'html');
```

Then it should work: 

``` js
app.get('/some-route', function(req, res) {
  res.render('some-view');
});
```

Tests are under `tests/express` directory.

There are some new `devDependencies`:
- [express 4.x](http://expressjs.com/)
- [supertest](https://github.com/visionmedia/supertest)
