### PR TITLE
Express: add index view support.

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -7,6 +7,7 @@ var builtin_filters = require('./filters');
 var builtin_loaders = require('./loaders');
 var runtime = require('./runtime');
 var globals = require('./globals');
+var express = require('./express');
 var Frame = runtime.Frame;
 
 var Environment = Obj.extend({
@@ -177,22 +178,7 @@ var Environment = Obj.extend({
     },
 
     express: function(app) {
-        var env = this;
-
-        function NunjucksView(name, opts) {
-            this.name          = name;
-            this.path          = name;
-            this.defaultEngine = opts.defaultEngine;
-            this.ext           = path.extname(name);
-            if (!this.ext && !this.defaultEngine) throw new Error('No default engine was specified and no extension was provided.');
-            if (!this.ext) this.name += (this.ext = ('.' !== this.defaultEngine[0] ? '.' : '') + this.defaultEngine);
-        }
-
-        NunjucksView.prototype.render = function(opts, cb) {
-          env.render(this.name, opts, cb);
-        };
-
-        app.set('view', NunjucksView);
+        express.configure(app, this);
     },
 
     render: function(name, ctx, cb) {

--- a/src/express.js
+++ b/src/express.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var fs   = require('fs');
+var path = require('path');
+
+function configure(app, env) {
+    app.set('view', NunjucksView.bind(null, env));
+}
+
+function NunjucksView(env, name, opts) {
+    this.env           = env;
+    this.name          = name;
+    this.defaultEngine = opts.defaultEngine;
+    this.ext           = path.extname(name);
+    if (!this.ext && !this.defaultEngine) throw new Error('No default engine was specified and no extension was provided.');
+    if (!this.ext) this.name += (this.ext = ('.' !== this.defaultEngine[0] ? '.' : '') + this.defaultEngine);
+    this.path = this.lookupPath();
+}
+
+NunjucksView.prototype.lookupPath = function() {
+    var fpath = this.name;
+    this.env.loaders.forEach(function(loader) {
+        loader.searchPaths.forEach(function(searchPath) {
+            var index     = path.join(path.basename(this.name, this.ext), 'index' + this.ext);
+            var indexpath = path.join(searchPath, index);
+            if (fs.existsSync(indexpath)) fpath = index;
+        }, this);
+    }, this);
+    return fpath;
+};
+
+NunjucksView.prototype.render = function(opts, cb) {
+    this.env.render(this.path, opts, cb);
+};
+
+module.exports = {
+    configure    : configure,
+    NunjucksView : NunjucksView
+};

--- a/tests/express-sample/views/indexview/index.html
+++ b/tests/express-sample/views/indexview/index.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+This is just the index page.
+{% endblock %}
+
+{% block footer %}
+{{ super() }}
+You really should read this!
+
+{{ poop }}
+{% endblock %}

--- a/tests/express/express.js
+++ b/tests/express/express.js
@@ -34,4 +34,13 @@ describe('express', function() {
             .expect(/This is just the about page/)
             .end(done);
     });
+
+    it('should render an index view', function(done) {
+        app.get('/', function(req, res) { res.render('indexview'); });
+        app.set('view engine', 'html');
+        request(app)
+            .get('/')
+            .expect(/This is just the index page/)
+            .end(done);
+    });
 });


### PR DESCRIPTION
This PR :

* Move Express-related code to `src/express.js`
* Add Express index view support ([see](https://github.com/visionmedia/express/blob/master/lib/view.js#L62))
* Add `tests/express-sample/views/indexview` folder
* Add `tests/express-sample/views/indexview/index.html` file
* Add a new test in `tests/express/express.js`

Example.

Let's create a folder `views/blog` and `views/blog/index.html`.

Then to render the view: 

```js
app.get('/blog', function(req, res) {
  res.render('blog'); // same as 'blog/index' or 'blog/index.html'
});
```

It's the default Express behavior.

Tell me if you rather prefer to keep the Express-related code into `src/environment.js`. 

I'm not sure I correctly use environment's `loaders`. I just iterate over them and their `searchPaths` property to check the index file existence. It's maybe (probably?) not the right way.