### PR TITLE
Implement 'in' comparison

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -173,6 +173,7 @@ var Compiler = Object.extend({
             nodes.LookupVal,
             nodes.Compare,
             nodes.InlineIf,
+            nodes.In,
             nodes.And,
             nodes.Or,
             nodes.Not,
@@ -361,6 +362,14 @@ var Compiler = Object.extend({
         else
             this.emit('""');
         this.emit(')');
+    },
+
+    compileIn: function(node, frame) {
+      this.emit('(');
+      this.compile(node.right, frame);
+      this.emit('.indexOf(');
+      this.compile(node.left, frame);
+      this.emit(') !== -1)');
     },
 
     compileOr: binOpEmitter(' || '),

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -119,6 +119,7 @@ var Output = NodeList.extend("Output");
 var TemplateData = Literal.extend("TemplateData");
 var UnaryOp = Node.extend("UnaryOp", { fields: ['target'] });
 var BinOp = Node.extend("BinOp", { fields: ['left', 'right'] });
+var In = BinOp.extend("In");
 var Or = BinOp.extend("Or");
 var And = BinOp.extend("And");
 var Not = UnaryOp.extend("Not");
@@ -278,6 +279,7 @@ module.exports = {
     Set: Set,
     LookupVal: LookupVal,
     BinOp: BinOp,
+    In: In,
     Or: Or,
     And: And,
     Not: Not,

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -363,6 +363,13 @@
                     bar: 15 },
                   'yes');
 
+            equal('{% if 1 in [1, 2] %}yes{% endif %}', 'yes');
+            equal('{% if 1 in [2, 3] %}yes{% endif %}', '');
+            equal('{% if 1 not in [1, 2] %}yes{% endif %}', '');
+            equal('{% if 1 not in [2, 3] %}yes{% endif %}', 'yes');
+            equal('{% if "a" in vals %}yes{% endif %}',
+                  {'vals': ['a', 'b']}, 'yes');
+
             finish(done);
         });
 

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -95,6 +95,10 @@
         }
 
         var type = ast[0];
+        // some nodes have fields (e.g. Compare.ops) which are plain arrays
+        if(type instanceof Array) {
+            return lib.map(ast, toNodes);
+        }
         var F = function() {};
         F.prototype = type.prototype;
 
@@ -190,6 +194,37 @@
                    [nodes.Output, [nodes.TemplateData, 'hello ']],
                    [nodes.Output, [nodes.Symbol, 'foo']],
                    [nodes.Output, [nodes.TemplateData, ', how are you']]]);
+        });
+
+        it('should parse operators', function() {
+            isAST(parser.parse('{{ x == y }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.Compare,
+                     [nodes.Symbol, 'x'],
+                     [[nodes.CompareOperand, [nodes.Symbol, 'y'], '==']]]]]);
+
+            isAST(parser.parse('{{ x or y }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.Or,
+                     [nodes.Symbol, 'x'],
+                     [nodes.Symbol, 'y']]]]);
+
+            isAST(parser.parse('{{ x in y }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.In,
+                     [nodes.Symbol, 'x'],
+                     [nodes.Symbol, 'y']]]]);
+
+            isAST(parser.parse('{{ x not in y }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.Not,
+                     [nodes.In,
+                      [nodes.Symbol, 'x'],
+                      [nodes.Symbol, 'y']]]]]);
         });
 
         it('should parse blocks', function() {


### PR DESCRIPTION
This fixes #115.

There was already code in place in `parseCompare` to parse `in` and `not in` as `Compare` nodes. This approach turned out to be problematic because of the implementation of chained `CompareOperand` nodes in `compileCompare`. Since the compilation of `in` and `not in` is not in-order, `compileCompare` would need to be significantly rewritten to support `in`. Such a rewrite could probably include adding better support for chained comparison operators (treating them as a series of ANDed pair comparisons; see https://github.com/jashkenas/coffeescript/issues/78), but this turned out to be complex (especially if we don't want to evaluate some expressions in the comparison chain multiple times), so I decided to consider it out of scope for this PR, and instead implemented `in` as a new `BinOp` node type, which works quite simply.
