### PR TITLE
Expose cycler.current

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -1,12 +1,12 @@
 
 function cycler(items) {
     var index = -1;
-    var current = null;
+    this.current = null;
 
     return {
         reset: function() {
             index = -1;
-            current = null;
+            this.current = null;
         },
 
         next: function() {
@@ -15,9 +15,9 @@ function cycler(items) {
                 index = 0;
             }
 
-            current = items[index];
-            return current;
-        }
+            this.current = items[index];
+            return this.current;
+        },
     };
 
 }

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -49,6 +49,12 @@
                   '{{ cls.next() }}',
                   'oddodd');
 
+            equal('{% set cls = cycler("odd", "even") %}' +
+                  '{{ cls.next() }}' +
+                  '{{ cls.next() }}' +
+                  '{{ cls.current }}',
+                  'oddeveneven');
+
             finish(done);
         });
 


### PR DESCRIPTION
This makes nunjucks consistent with the Jinja2 cycler api.

Fixes #266.
