### PR TITLE
Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
(Continued from #279)

I know how easy it is for those kind of files to explode if you add Sublime/NetBeans/Eclipse config files, but .editorconfig is meant to be a cross-editor configuration file and makes it quicker to start writing code without having to worry about setting up tabs/spaces/indentation. It has plugins for most major editors. See http://editorconfig.org/
