### PR TITLE
precompile command for Windows

### DIFF
--- a/bin/precompile.cmd
+++ b/bin/precompile.cmd
@@ -1,0 +1,5 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\precompile" %*
+) ELSE (
+  node  "%~dp0\precompile" %*
+)


### PR DESCRIPTION
Allow Windows users to precompile templates from the command line.
