### PR TITLE
Precompile templates to modules

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -6,7 +6,7 @@ var lib = require('../src/lib');
 
 var optimist = require('optimist')
 
-    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] <path>')
+    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-o|--output <format>] <path>')
     .wrap(80)
 
     .describe('help', 'Display this help message')
@@ -36,6 +36,21 @@ var optimist = require('optimist')
         .default('exclude', [])
         .alias('x', 'exclude')
 
+    .describe('output', 'change the output format. Available options: global, amd, cjs, esm')
+        .string('output' )
+        .default('output', 'global')
+        .alias('o', 'output')
+        .check(function(argv) {
+            var valid = {
+                    global: true,
+                    amd: true,
+                    cjs: true,
+                    esm: true
+                },
+                format = argv.format;
+            if ( format && !valid[format] ) throw 'Invalid output format '+format;
+        })
+
     .demand(1);
 
 var argv = optimist.argv;
@@ -58,6 +73,7 @@ console.log(precompile(argv._[0], {
     name : argv.name,
 
     include : [].concat(argv.include),
-    exclude : [].concat(argv.exclude)
+    exclude : [].concat(argv.exclude),
+    format : argv.output
 
 }));

--- a/src/precompile-amd.js
+++ b/src/precompile-amd.js
@@ -1,0 +1,9 @@
+function precompileAMD(name, body, opts) {
+    var eol = opts.eol || '\n';
+
+    var out = 'define(' + JSON.stringify(name) + ', function() {' + eol +
+        body + eol + '});' + eol;
+    return out;
+}
+
+module.exports = precompileAMD;

--- a/src/precompile-cjs.js
+++ b/src/precompile-cjs.js
@@ -1,0 +1,14 @@
+function precompileCJS(name, body, opts) {
+    var eol = opts.eol || '\n';
+
+    var out = 'module.exports = {' + eol;
+    out += '  name: ' + JSON.stringify(name) + ',' + eol;
+    out += '  template: (function() {' + eol;
+    out += body + eol;
+    out += '  })()' + eol;
+    out += '};';
+
+    return out;
+}
+
+module.exports = precompileCJS;

--- a/src/precompile-esm.js
+++ b/src/precompile-esm.js
@@ -1,0 +1,15 @@
+function precompileESModule(name, body, opts) {
+    var eol = opts.eol || '\n';
+
+    var out = 'var template = {' + eol;
+    out += '  name: ' + JSON.stringify(name) + ',' + eol;
+    out += '  template: (function() {' + eol;
+    out += body + eol;
+    out += '  })()' + eol;
+    out += '};' + eol + eol;
+    out += 'export default template;' + eol;
+
+    return out;
+}
+
+module.exports = precompileESModule;

--- a/src/precompile-global.js
+++ b/src/precompile-global.js
@@ -1,0 +1,16 @@
+function precompileGlobal(name, body, opts) {
+    var eol = opts.eol || '\n';
+
+    var out = '(function() {' +
+        '(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})' +
+        '["' + name + '"] = (function() {' + body + '})();' + eol;
+
+    if(opts && opts.asFunction) {
+        out += 'return function(ctx, cb) { return nunjucks.render("' + name + '", ctx, cb); }';
+    }
+
+    out += '})();' + eol;
+    return out;
+}
+
+module.exports = precompileGlobal;

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -193,7 +193,7 @@ function convertStatements(ast) {
         });
 
         if(async) {
-	        if(node instanceof nodes.If) {
+            if(node instanceof nodes.If) {
                 return new nodes.IfAsync(
                     node.lineno,
                     node.colno,


### PR DESCRIPTION
One may want to store templates in modules, instead of a global variable. This allows Node to use templates precompiled to CJS. But a new loader will be required.

For now, the templates are exported as default, but it may be expanded to named exports in the future, to allow to store many templates in one module.
