### PR TITLE
async rendering doesn't throw anymore when encountering compilation errors

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -342,7 +342,13 @@ var Template = Obj.extend({
         }
 
         return lib.withPrettyErrors(this.path, this.env.dev, function() {
-            this.compile();
+            try {
+                this.compile();
+            } catch (e) {
+                if (cb) cb(e);
+                else throw e;
+                return;
+            }
 
             var context = new Context(ctx || {}, this.blocks);
             var syncResult = null;
@@ -361,7 +367,13 @@ var Template = Obj.extend({
     },
 
     getExported: function(cb) {
-        this.compile();
+        try {
+            this.compile();
+        } catch (e) {
+            if (cb) cb(e);
+            else throw e;
+            return;
+        }
 
         // Run the rootRenderFunc to populate the context with exported vars
         var context = new Context({}, this.blocks);


### PR DESCRIPTION
fixes http://github.com/mozilla/nunjucks/issues/233

when calling the `render` or `renderString` method with a callback and the template contains a syntax error an error is thrown instead of returning the error to the callback. This patch fixes this behavior. Compilation errors are now returned to the callback.