### PR TITLE
Fix broken compatibility link

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -85,7 +85,7 @@ features, it should be easy to make templates compatible. In the
 <a href="https://marketplace.firefox.com/">Firefox Marketplace</a>, the devs
 actually created a compatibility layer that overrides some of nunjucks
 internals to provide better jinja2 compatiblity (allowing the use of
-<code>True</code> and more). You can <a href="https://github.com/mozilla/fireplace/blob/master/hearth/media/js/lib/nunjucks.compat.js">see it
+<code>True</code> and more). You can <a href="https://github.com/mozilla/fireplace/blob/9fb5f147c136926e406fd725e4062b0866d431c4/src/media/js/lib/nunjucks.compat.js">see it
 here</a>.</p>
 
 <p>Additionally, there are few jinja2 features not implemented in nunjucks:</p>


### PR DESCRIPTION
This link was broken since a while.

I am not sure if the entire paragraph is meaningful, as in [655de4609](https://github.com/mozilla/fireplace/commit/655de46095bbe181d5afed54842e99fcc477d5ed) Fireplace has removed the entire compatibility library with the message "upgrade to bower", but I kind of missing where was it moved (if at all).
Currently Fireplace [doesn't have that functionality](https://github.com/mozilla/fireplace/search?q=itervalues), so, unless some of added Bower libraries implement it ([don't see that](https://github.com/mozilla/fireplace/commit/655de46095bbe181d5afed54842e99fcc477d5ed#diff-0a08a7565aba4405282251491979bb6bR5)), the functionality was removed.
