### PR TITLE
Bind 'in' operator more tightly than boolean operators.

### DIFF
--- a/tests/parser.js
+++ b/tests/parser.js
@@ -236,6 +236,36 @@
                       [nodes.Symbol, 'y']]]]]);
         });
 
+        it('should parse operators with correct precedence', function() {
+            isAST(parser.parse('{{ x in y and z }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.And,
+                     [nodes.In,
+                      [nodes.Symbol, 'x'],
+                      [nodes.Symbol, 'y']],
+                     [nodes.Symbol, 'z']]]]);
+
+            isAST(parser.parse('{{ x not in y or z }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.Or,
+                     [nodes.Not,
+                      [nodes.In,
+                      [nodes.Symbol, 'x'],
+                       [nodes.Symbol, 'y']]],
+                     [nodes.Symbol, 'z']]]]);
+
+            isAST(parser.parse('{{ x or y and z }}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.Or,
+                     [nodes.Symbol, 'x'],
+                     [nodes.And,
+                      [nodes.Symbol, 'y'],
+                      [nodes.Symbol, 'z']]]]]);
+        });
+
         it('should parse blocks', function() {
             var n = parser.parse('want some {% if hungry %}pizza{% else %}' +
                                  'water{% endif %}?');


### PR DESCRIPTION
When I added support for the 'in' operator a couple months ago, I think I got the precedence slightly wrong.

JS has no 'in' operator, so there's nothing to base nunjucks' behavior off there, but Python (https://docs.python.org/2/reference/expressions.html#operator-precedence) and Jinja both bind 'in' more tightly than boolean operators, so that this `{% if msg.status in ['pending', 'confirmed'] and msg.body %}` does not evaluate as `{% if msg.status in (['pending', 'confirmed'] and msg.body) %}` (which is what nunjucks master currently does).

I think the Python/Jinja behavior is more useful and logical than nunjucks' current behavior: `in` is a comparison operator, like `==` et al, and should bind with similar precedence. You wouldn't expect `{% if msg.status == 'pending' and msg.body %}` to evaluate as `{% if msg.status == ('pending' and msg.body) %}`.

This pull request fixes the precedence (and while I was at it, also adds a test to confirm that `and` binds more tightly than `or`, which is correct and matches both Python and JS).