### PR TITLE
Patching serverside script injection

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -207,6 +207,12 @@ function suppressValue(val, autoescape) {
 function memberLookup(obj, val) {
     obj = obj || {};
 
+    if (val == '__proto__' || val == 'constructor') {
+        return function() {
+            return function() {};
+        }
+    }
+
     if(typeof obj[val] === 'function') {
         return function() {
             return obj[val].apply(obj, arguments);

--- a/tests/runtime.js
+++ b/tests/runtime.js
@@ -67,5 +67,18 @@
 
             finish(done);
         });
+
+        it('should skip invoking constructors and render blank output', function(done) {
+            render('{{ a.constructor.__proto__.constructor(\'return "fail"\')() }}',
+                   {},
+                   { noThrow: true },
+                   function(err, res) {
+                       expect(err).to.equal(null);
+                       expect(typeof res).to.be('string');
+                       expect(res).to.be('');
+                   });
+
+            finish(done);
+        });
     });
 })();


### PR DESCRIPTION
Nunjucks currently has the ability to execute code in serverside Node.js context.

```
{{ a.constructor.__proto__.constructor('process.kill()')() }}
```

This PR will make the runtime skip self invoking constructors created inside Nunjucks templates.

https://github.com/mozilla/nunjucks-docs/issues/17