### PR TITLE
Update to chokidar 0.12.5 (fix fsevents compilation on OS X)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "James Long <longster@gmail.com>",
     "dependencies": {
         "optimist": "*",
-        "chokidar": "~0.8.2"
+        "chokidar": "~0.12.5"
     },
     "browser" : "./browser/nunjucks.js",
     "devDependencies": {


### PR DESCRIPTION
I was having compilation issues (https://github.com/pipobscure/fsevents/issues/33) which have been fixed in fsevents 0.3.1 and chokidar 0.12.5.