### PR TITLE
Accept relative paths in import/include

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -33,7 +33,8 @@ function quotedArray(arr) {
 }
 
 var Compiler = Object.extend({
-    init: function() {
+    init: function(name) {
+        this.name = name;
         this.codebuf = [];
         this.lastId = 0;
         this.buffer = null;
@@ -60,6 +61,7 @@ var Compiler = Object.extend({
     },
 
     emit: function(code) {
+        //console.log("emit", code);
         this.codebuf.push(code);
     },
 
@@ -891,7 +893,7 @@ var Compiler = Object.extend({
 
         this.emit('env.getTemplate(');
         this._compileExpression(node.template, frame);
-        this.emitLine(', ' + this.makeCallback(id));
+        this.emitLine(', false, "'+this.name+'", ' + this.makeCallback(id));
         this.addScopeLevel();
 
         this.emitLine(id + '.getExported(' +
@@ -914,7 +916,7 @@ var Compiler = Object.extend({
 
         this.emit('env.getTemplate(');
         this._compileExpression(node.template, frame);
-        this.emitLine(', ' + this.makeCallback(importedId));
+        this.emitLine(', false, "'+this.name+'", ' + this.makeCallback(importedId));
         this.addScopeLevel();
 
         this.emitLine(importedId + '.getExported(' +
@@ -989,7 +991,7 @@ var Compiler = Object.extend({
 
         this.emit('env.getTemplate(');
         this._compileExpression(node.template, frame);
-        this.emitLine(', true, ' + this.makeCallback('parentTemplate'));
+        this.emitLine(', true, "'+this.name+'", ' + this.makeCallback('parentTemplate'));
 
         this.emitLine('for(var ' + k + ' in parentTemplate.blocks) {');
         this.emitLine('context.addBlock(' + k +
@@ -1006,7 +1008,7 @@ var Compiler = Object.extend({
 
         this.emit('env.getTemplate(');
         this._compileExpression(node.template, frame);
-        this.emitLine(', ' + this.makeCallback(id));
+        this.emitLine(', false, "'+this.name+'", '+ this.makeCallback(id));
         this.addScopeLevel();
 
         this.emitLine(id + '.render(' +

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1106,7 +1106,7 @@ var Compiler = Object.extend({
 
 module.exports = {
     compile: function(src, asyncFilters, extensions, name, opts) {
-        var c = new Compiler();
+        var c = new Compiler(name);
 
         // Run the extension preprocessors against the source.
         if(extensions && extensions.length) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -99,15 +99,15 @@ var Environment = Obj.extend({
         return this.filters[name];
     },
 
-    getTemplate: function(name, eagerCompile, fromName, cb) {
+    getTemplate: function(name, eagerCompile, parentName, cb) {
         if(name && name.raw) {
             // this fixes autoescape for templates referenced in symbols
             name = name.raw;
         }
 
-        if(lib.isFunction(fromName)) {
-            cb = fromName;
-            fromName = null;
+        if(lib.isFunction(parentName)) {
+            cb = parentName;
+            parentName = null;
             eagerCompile = eagerCompile || false;
         }
 
@@ -118,6 +118,11 @@ var Environment = Obj.extend({
 
         if(typeof name !== 'string') {
             throw new Error('template names must be a string: ' + name);
+        }
+
+        // Resolve name relative to parentName
+        if (parentName && (name.indexOf("./") == 0 || name.indexOf("../") == 0)) {
+            name = path.resolve(parentName, name);
         }
 
         var tmpl = this.cache[name];

--- a/src/environment.js
+++ b/src/environment.js
@@ -99,10 +99,16 @@ var Environment = Obj.extend({
         return this.filters[name];
     },
 
-    getTemplate: function(name, eagerCompile, cb) {
+    getTemplate: function(name, eagerCompile, fromName, cb) {
         if(name && name.raw) {
             // this fixes autoescape for templates referenced in symbols
             name = name.raw;
+        }
+
+        if(lib.isFunction(fromName)) {
+            cb = fromName;
+            fromName = null;
+            eagerCompile = eagerCompile || false;
         }
 
         if(lib.isFunction(eagerCompile)) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -122,7 +122,7 @@ var Environment = Obj.extend({
 
         // Resolve name relative to parentName
         if (parentName && (name.indexOf("./") == 0 || name.indexOf("../") == 0)) {
-            name = path.resolve(parentName, name);
+            name = path.resolve(path.dirname(parentName), name);
         }
 
         var tmpl = this.cache[name];

--- a/src/environment.js
+++ b/src/environment.js
@@ -240,8 +240,14 @@ var Environment = Obj.extend({
         return syncResult;
     },
 
-    renderString: function(src, ctx, cb) {
-        var tmpl = new Template(src, this);
+    renderString: function(src, ctx, opts, cb) {
+        if(lib.isFunction(opts)) {
+            cb = opts;
+            opts = {};
+        }
+        opts = opts || {};
+
+        var tmpl = new Template(src, this, opts.path);
         return tmpl.render(ctx, cb);
     }
 });

--- a/src/environment.js
+++ b/src/environment.js
@@ -120,11 +120,6 @@ var Environment = Obj.extend({
             throw new Error('template names must be a string: ' + name);
         }
 
-        // Resolve name relative to parentName
-        if (parentName && (name.indexOf("./") == 0 || name.indexOf("../") == 0)) {
-            name = path.resolve(path.dirname(parentName), name);
-        }
-
         var tmpl = this.cache[name];
 
         if(tmpl) {
@@ -149,6 +144,11 @@ var Environment = Obj.extend({
                     else {
                         next();
                     }
+                }
+
+                // Resolve name relative to parentName
+                if (parentName && (name.indexOf("./") == 0 || name.indexOf("../") == 0)) {
+                    name = loader.resolve(parentName, name);
                 }
 
                 if(loader.async) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var Obj = require('./object');
 var lib = require('./lib');
 
@@ -16,6 +17,10 @@ var Loader = Obj.extend({
                 listener.apply(null, args);
             });
         }
+    },
+
+    resolve: function(from, to) {
+        return path.resolve(path.dirname(from), to);
     }
 });
 

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -43,12 +43,12 @@ var FileSystemLoader = Loader.extend({
         var paths = this.searchPaths;
 
         for(var i=0; i<paths.length; i++) {
+            var basePath = path.resolve(paths[i]);
             var p = path.resolve(paths[i], name);
 
             // Only allow the current directory and anything
             // underneath it to be searched
-            if((paths[i] == '.' || p.indexOf(paths[i]) === 0) &&
-               existsSync(p)) {
+            if(p.indexOf(basePath) === 0 && existsSync(p)) {
                 fullpath = p;
                 break;
             }

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -43,7 +43,7 @@ var FileSystemLoader = Loader.extend({
         var paths = this.searchPaths;
 
         for(var i=0; i<paths.length; i++) {
-            var p = path.join(paths[i], name);
+            var p = path.resolve(paths[i], name);
 
             // Only allow the current directory and anything
             // underneath it to be searched

--- a/tests/api.js
+++ b/tests/api.js
@@ -1,5 +1,6 @@
 (function() {
     var expect, Environment, Loader, templatesPath;
+    var path = require('path');
 
     if(typeof require != 'undefined') {
         expect = require('expect.js');
@@ -35,7 +36,9 @@
 
         it('should handle correctly relative paths in renderString', function() {
             var env = new Environment(new Loader(templatesPath));
-            expect(env.renderString('{% extends "./relative/test1.html" %}{% block block1 %}Test3{% endblock %}')).to.be('FooTest3BazFizzle');
+            expect(env.renderString('{% extends "./relative/test1.html" %}{% block block1 %}Test3{% endblock %}', {}, {
+                path: path.resolve(templatesPath, "string.html")
+            })).to.be('FooTest3BazFizzle');
         });
     });
 })();

--- a/tests/api.js
+++ b/tests/api.js
@@ -22,5 +22,15 @@
             var child = env.getTemplate('base-inherit.html');
             expect(child.render()).to.be('Foo*Bar*BazFizzle');
         });
+
+        it('should handle correctly relative paths', function() {
+            var env = new Environment(new Loader(templatesPath));
+
+            var child1 = env.getTemplate('relative/test1.html');
+            var child2 = env.getTemplate('relative/test2.html');
+
+            expect(child1.render()).to.be('FooTest1BazFizzle');
+            expect(child2.render()).to.be('FooTest2BazFizzle');
+        });
     });
 })();

--- a/tests/api.js
+++ b/tests/api.js
@@ -32,5 +32,10 @@
             expect(child1.render()).to.be('FooTest1BazFizzle');
             expect(child2.render()).to.be('FooTest2BazFizzle');
         });
+
+        it('should handle correctly relative paths in renderString', function() {
+            var env = new Environment(new Loader(templatesPath));
+            expect(env.renderString('{% extends "./relative/test1.html" %}{% block block1 %}Test3{% endblock %}')).to.be('FooTest3BazFizzle');
+        });
     });
 })();

--- a/tests/templates/relative/test1.html
+++ b/tests/templates/relative/test1.html
@@ -1,0 +1,3 @@
+{% extends "../base.html" %}
+
+{% block block1 %}Test1{% endblock %}

--- a/tests/templates/relative/test2.html
+++ b/tests/templates/relative/test2.html
@@ -1,0 +1,3 @@
+{% extends "./test1.html" %}
+
+{% block block1 %}Test2{% endblock %}


### PR DESCRIPTION
This PR fixes #228,#326, #243. It simply lets you use `../` and `./` in **import** and **include**.

- [x] Pass path of current template to `env.getTemplate`
- [x] Add tests

### Example:

```
- folder1/
    - test.html
    - test2.html
- layout.html
```

test.html:
```html
{% extends ../layout.html %}

{% block test %}
Hello
{% endblock %}
```

test2.html:
```html
{% extends ./test.html %}

{% block test %}
Hello 2
{% endblock %}
```

In another matter, I don't think this line https://github.com/mozilla/nunjucks/blob/master/src/environment.js#L142 is a good idea, because if you're using an async loader inside your express application, the app crash if the loader return an error in the callback. The error should be passed to the callback (or throwned if sync): line 163.