### PR TITLE
Implement lstripBlocks and trimBlocks from Jinja2

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1103,7 +1103,7 @@ var Compiler = Object.extend({
 // console.log(tmpl);
 
 module.exports = {
-    compile: function(src, asyncFilters, extensions, name, lexerTags) {
+    compile: function(src, asyncFilters, extensions, name, lexerTags, trimBlocks, lstripBlocks) {
         var c = new Compiler();
 
         // Run the extension preprocessors against the source.
@@ -1115,7 +1115,11 @@ module.exports = {
             }
         }
 
-        c.compile(transformer.transform(parser.parse(src, extensions, lexerTags),
+        c.compile(transformer.transform(parser.parse(src,
+                                                     extensions,
+                                                     lexerTags,
+                                                     trimBlocks,
+                                                     lstripBlocks),
                                         asyncFilters,
                                         name));
         return c.getCode();

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -130,7 +130,7 @@ var Compiler = Object.extend({
     _bufferAppend: function(func) {
         this.emit(this.buffer + ' += runtime.suppressValue(');
         func.call(this);
-        this.emit(', env.autoesc);\n');
+        this.emit(', env.opts.autoescape);\n');
     },
 
     _compileChildren: function(node, frame) {
@@ -277,12 +277,12 @@ var Compiler = Object.extend({
         if(async) {
             var res = this.tmpid();
             this.emitLine(', ' + this.makeCallback(res));
-            this.emitLine(this.buffer + ' += runtime.suppressValue(' + res + ', ' + autoescape + ' && env.autoesc);');
+            this.emitLine(this.buffer + ' += runtime.suppressValue(' + res + ', ' + autoescape + ' && env.opts.autoescape);');
             this.addScopeLevel();
         }
         else {
             this.emit(')');
-            this.emit(', ' + autoescape + ' && env.autoesc);\n');
+            this.emit(', ' + autoescape + ' && env.opts.autoescape);\n');
         }
     },
 
@@ -427,7 +427,7 @@ var Compiler = Object.extend({
         this._compileExpression(node.target, frame);
         this.emit('),');
         this._compileExpression(node.val, frame);
-        this.emit(', env.autoesc)');
+        this.emit(', env.opts.autoescape)');
     },
 
     _getNodeName: function(node) {
@@ -1034,7 +1034,7 @@ var Compiler = Object.extend({
             else {
                 this.emit(this.buffer + ' += runtime.suppressValue(');
                 this.compile(children[i], frame);
-                this.emit(', env.autoesc);\n');
+                this.emit(', env.opts.autoescape);\n');
             }
         }
     },
@@ -1103,7 +1103,7 @@ var Compiler = Object.extend({
 // console.log(tmpl);
 
 module.exports = {
-    compile: function(src, asyncFilters, extensions, name, lexerTags, trimBlocks, lstripBlocks) {
+    compile: function(src, asyncFilters, extensions, name, opts) {
         var c = new Compiler();
 
         // Run the extension preprocessors against the source.
@@ -1117,9 +1117,7 @@ module.exports = {
 
         c.compile(transformer.transform(parser.parse(src,
                                                      extensions,
-                                                     lexerTags,
-                                                     trimBlocks,
-                                                     lstripBlocks),
+                                                     opts),
                                         asyncFilters,
                                         name));
         return c.getCode();

--- a/src/environment.js
+++ b/src/environment.js
@@ -17,19 +17,18 @@ var Environment = Obj.extend({
         // (the full trace from within nunjucks may confuse developers using
         //  the library)
         // defaults to false
-        opts = opts || {};
-        this.dev = !!opts.dev;
-        this.lexerTags = opts.tags;
+        var opts = this.opts = opts || {};
+        this.opts.dev = !!opts.dev;
 
         // The autoescape flag sets global autoescaping. If true,
         // every string variable will be escaped by default.
         // If false, strings can be manually escaped using the `escape` filter.
         // defaults to false
-        this.autoesc = !!opts.autoescape;
+        this.opts.autoescape = !!opts.autoescape;
 
-        this.trimBlocks = !!opts.trimBlocks;
+        this.opts.trimBlocks = !!opts.trimBlocks;
 
-        this.lstripBlocks = !!opts.lstripBlocks;
+        this.opts.lstripBlocks = !!opts.lstripBlocks;
 
         if(!loaders) {
             // The filesystem loader is only available client-side
@@ -419,9 +418,7 @@ var Template = Obj.extend({
                                           this.env.asyncFilters,
                                           this.env.extensionsList,
                                           this.path,
-                                          this.env.lexerTags,
-                                          this.env.trimBlocks,
-                                          this.env.lstripBlocks);
+                                          this.env.opts);
 
             var func = new Function(source);
             props = func();

--- a/src/environment.js
+++ b/src/environment.js
@@ -27,6 +27,10 @@ var Environment = Obj.extend({
         // defaults to false
         this.autoesc = !!opts.autoescape;
 
+        this.trimBlocks = !!opts.trimBlocks;
+
+        this.lstripBlocks = !!opts.lstripBlocks;
+
         if(!loaders) {
             // The filesystem loader is only available client-side
             if(builtin_loaders.FileSystemLoader) {
@@ -415,7 +419,9 @@ var Template = Obj.extend({
                                           this.env.asyncFilters,
                                           this.env.extensionsList,
                                           this.path,
-                                          this.env.lexerTags);
+                                          this.env.lexerTags,
+                                          this.env.trimBlocks,
+                                          this.env.lstripBlocks);
 
             var func = new Function(source);
             props = func();

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -45,7 +45,7 @@ function token(type, value, lineno, colno) {
     };
 }
 
-function Tokenizer(str, tags, trimBlocks, lstripBlocks) {
+function Tokenizer(str, opts) {
     this.str = str;
     this.index = 0;
     this.len = str.length;
@@ -54,7 +54,9 @@ function Tokenizer(str, tags, trimBlocks, lstripBlocks) {
 
     this.in_code = false;
 
-    tags = tags || {};
+    opts = opts || {};
+
+    tags = opts.tags || {};
     this.tags = {
         BLOCK_START: tags.blockStart || BLOCK_START,
         BLOCK_END: tags.blockEnd || BLOCK_END,
@@ -64,18 +66,18 @@ function Tokenizer(str, tags, trimBlocks, lstripBlocks) {
         COMMENT_END: tags.commentEnd || COMMENT_END
     };
 
-    this.trimBlocks = !!trimBlocks;
-    this.lstripBlocks = !!lstripBlocks;
+    this.trimBlocks = !!opts.trimBlocks;
+    this.lstripBlocks = !!opts.lstripBlocks;
 }
 
 Tokenizer.prototype.nextToken = function() {
     var lineno = this.lineno;
     var colno = this.colno;
+    var tok;
 
     if(this.in_code) {
         // Otherwise, if we are in a block parse it as code
         var cur = this.current();
-        var tok;
 
         if(this.is_finished()) {
             // We have nothing else to parse
@@ -205,7 +207,6 @@ Tokenizer.prototype.nextToken = function() {
                           this.tags.VARIABLE_START.charAt(0) +
                           this.tags.COMMENT_START.charAt(0) +
                           this.tags.COMMENT_END.charAt(0));
-        var tok;
 
         if(this.is_finished()) {
             return null;
@@ -437,8 +438,8 @@ Tokenizer.prototype.previous = function() {
 };
 
 module.exports = {
-    lex: function(src, tags, trimBlocks, lstripBlocks) {
-        return new Tokenizer(src, tags, trimBlocks, lstripBlocks);
+    lex: function(src, opts) {
+        return new Tokenizer(src, opts);
     },
 
     TOKEN_STRING: TOKEN_STRING,

--- a/src/parser.js
+++ b/src/parser.js
@@ -1189,8 +1189,8 @@ var Parser = Object.extend({
 // nodes.printNodes(n);
 
 module.exports = {
-    parse: function(src, extensions, lexerTags, trimBlocks, lstripBlocks) {
-        var p = new Parser(lexer.lex(src, lexerTags, trimBlocks, lstripBlocks));
+    parse: function(src, extensions, opts) {
+        var p = new Parser(lexer.lex(src, opts));
         if (extensions !== undefined) {
             p.extensions = extensions;
         }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1189,8 +1189,8 @@ var Parser = Object.extend({
 // nodes.printNodes(n);
 
 module.exports = {
-    parse: function(src, extensions, lexerTags) {
-        var p = new Parser(lexer.lex(src, lexerTags));
+    parse: function(src, extensions, lexerTags, trimBlocks, lstripBlocks) {
+        var p = new Parser(lexer.lex(src, lexerTags, trimBlocks, lstripBlocks));
         if (extensions !== undefined) {
             p.extensions = extensions;
         }

--- a/tests/lexer.js
+++ b/tests/lexer.js
@@ -72,7 +72,7 @@
         });
 
         it('should trim blocks', function () {
-            tokens = lexer.lex('  {% if true %}\n    foo\n  {% endif %}\n', undefined, true);
+            tokens = lexer.lex('  {% if true %}\n    foo\n  {% endif %}\n', {trimBlocks: true});
             hasTokens(tokens,
                       [lexer.TOKEN_DATA, '  '],
                       lexer.TOKEN_BLOCK_START,
@@ -86,7 +86,10 @@
         });
 
         it('should lstrip and trim blocks', function () {
-            tokens = lexer.lex('test\n {% if true %}\n  foo\n {% endif %}\n</div>', undefined, true, true);
+            tokens = lexer.lex('test\n {% if true %}\n  foo\n {% endif %}\n</div>', {
+                lstripBlocks: true,
+                trimBlocks: true
+            });
             hasTokens(tokens,
                       [lexer.TOKEN_DATA, 'test\n'],
                       lexer.TOKEN_BLOCK_START,
@@ -101,7 +104,7 @@
         });
 
         it('should lstrip and not collapse whitespace between blocks', function () {
-            tokens = lexer.lex('   {% t %} {% t %}', undefined, false, true);
+            tokens = lexer.lex('   {% t %} {% t %}', {lstripBlocks: true});
             hasTokens(tokens,
                       lexer.TOKEN_BLOCK_START,
                       lexer.TOKEN_SYMBOL,
@@ -284,7 +287,7 @@
         }),
 
         it('should allow changing the variable start and end', function() {
-            tokens = lexer.lex('data {= var =}', {variableStart: '{=', variableEnd: '=}'});
+            tokens = lexer.lex('data {= var =}', {tags: {variableStart: '{=', variableEnd: '=}'}});
             hasTokens(tokens,
                       lexer.TOKEN_DATA,
                       lexer.TOKEN_VARIABLE_START,
@@ -293,14 +296,14 @@
         }),
 
         it('should allow changing the block start and end', function() {
-            tokens = lexer.lex('{= =}', {blockStart: '{=', blockEnd: '=}'});
+            tokens = lexer.lex('{= =}', {tags: {blockStart: '{=', blockEnd: '=}'}});
             hasTokens(tokens,
                       lexer.TOKEN_BLOCK_START,
                       lexer.TOKEN_BLOCK_END);
         }),
 
         it('should allow changing the variable start and end', function() {
-            tokens = lexer.lex('data {= var =}', {variableStart: '{=', variableEnd: '=}'});
+            tokens = lexer.lex('data {= var =}', {tags: {variableStart: '{=', variableEnd: '=}'}});
             hasTokens(tokens,
                       lexer.TOKEN_DATA,
                       lexer.TOKEN_VARIABLE_START,
@@ -309,7 +312,7 @@
         }),
 
         it('should allow changing the comment start and end', function() {
-            tokens = lexer.lex('<!-- A comment! -->', {commentStart: '<!--', commentEnd: '-->'});
+            tokens = lexer.lex('<!-- A comment! -->', {tags: {commentStart: '<!--', commentEnd: '-->'}});
             hasTokens(tokens,
                       lexer.TOKEN_COMMENT);
         }),
@@ -318,13 +321,13 @@
          * Test that this bug is fixed: https://github.com/mozilla/nunjucks/issues/235
          */
         it('should have individual lexer tag settings for each environment', function() {
-            tokens = lexer.lex('{=', {variableStart: '{='});
+            tokens = lexer.lex('{=', {tags: {variableStart: '{='}});
             hasTokens(tokens, lexer.TOKEN_VARIABLE_START);
 
             tokens = lexer.lex('{{');
             hasTokens(tokens, lexer.TOKEN_VARIABLE_START);
 
-            tokens = lexer.lex('{{', {variableStart: '<<<'});
+            tokens = lexer.lex('{{', {tags: {variableStart: '<<<'}});
             hasTokens(tokens, lexer.TOKEN_DATA);
 
             tokens = lexer.lex('{{');

--- a/tests/lexer.js
+++ b/tests/lexer.js
@@ -71,6 +71,48 @@
                             lexer.TOKEN_DATA);
         });
 
+        it('should trim blocks', function () {
+            tokens = lexer.lex('  {% if true %}\n    foo\n  {% endif %}\n', undefined, true);
+            hasTokens(tokens,
+                      [lexer.TOKEN_DATA, '  '],
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BOOLEAN,
+                      lexer.TOKEN_BLOCK_END,
+                      [lexer.TOKEN_DATA, '    foo\n  '],
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BLOCK_END);
+        });
+
+        it('should lstrip and trim blocks', function () {
+            tokens = lexer.lex('test\n {% if true %}\n  foo\n {% endif %}\n</div>', undefined, true, true);
+            hasTokens(tokens,
+                      [lexer.TOKEN_DATA, 'test\n'],
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BOOLEAN,
+                      lexer.TOKEN_BLOCK_END,
+                      [lexer.TOKEN_DATA, '  foo\n'],
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BLOCK_END,
+                      [lexer.TOKEN_DATA, '</div>']);
+        });
+
+        it('should lstrip and not collapse whitespace between blocks', function () {
+            tokens = lexer.lex('   {% t %} {% t %}', undefined, false, true);
+            hasTokens(tokens,
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BLOCK_END,
+                      [lexer.TOKEN_DATA, ' '],
+                      lexer.TOKEN_BLOCK_START,
+                      lexer.TOKEN_SYMBOL,
+                      lexer.TOKEN_BLOCK_END);
+        });
+
+
         it('should parse variable start and end', function() {
             tokens = lexer.lex('data {{ foo }} bar bizzle');
             hasTokens(tokens,


### PR DESCRIPTION
This pull request implements functionality from Jinja2 trim_blocks and lstrip_blocks (renaming to camelCase).
It can significantly reduce amount of whitespace in the output if a lot of block tags are used.