### PR TITLE
Allow list filter to pass arrays through as-is.

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -173,6 +173,9 @@ var filters = {
                          value: val[k] };
             });
         }
+        else if(lib.isArray(val)) {
+          return val;
+        }
         else {
             throw new lib.TemplateError("list filter: type not iterable");
         }

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -189,8 +189,12 @@
         });
 
         it('list', function(done) {
+            var person = {name: "Joe", age: 83};
             equal('{% for i in "foobar" | list %}{{ i }},{% endfor %}',
                   'f,o,o,b,a,r,');
+            equal('{% for pair in person | list %}{{ pair.key }}: {{ pair.value }} - {% endfor %}',
+                  {person: person}, 'name: Joe - age: 83 - ');
+            equal('{% for i in [1, 2] | list %}{{ i }}{% endfor %}', '12');
             finish(done);
         });
 


### PR DESCRIPTION
It's a bit silly for the `|list` filter to say "type not iterable" when given an array; it should just pass the array through unchanged instead.

This PR does that, and also adds a test for the currently-untested case of passing an object to `|list`.