### PR TITLE
Add support for selectattr and rejectattr filters.

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -186,6 +186,18 @@ var filters = {
         return arr[Math.floor(Math.random() * arr.length)];
     },
 
+    rejectattr: function(arr, attr) {
+      return arr.filter(function (item) {
+        return !item[attr];
+      });
+    },
+
+    selectattr: function(arr, attr) {
+      return arr.filter(function (item) {
+        return !!item[attr];
+      });
+    },
+
     replace: function(str, old, new_, maxCount) {
         if (old instanceof RegExp) {
             return str.replace(old, new_);

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -210,6 +210,18 @@
             finish(done);
         });
 
+        it('rejectattr', function(done) {
+          var foods = [{tasty: true}, {tasty: false}, {tasty: true}];
+          equal('{{ foods | rejectattr("tasty") | length }}', {foods: foods}, '1');
+          finish(done);
+        });
+
+        it('selectattr', function(done) {
+          var foods = [{tasty: true}, {tasty: false}, {tasty: true}];
+          equal('{{ foods | selectattr("tasty") | length }}', {foods: foods}, '2');
+          finish(done);
+        });
+
         it('replace', function(done) {
             equal('{{ "aaabbbccc" | replace("a", "x") }}', 'xxxbbbccc');
             equal('{{ "aaabbbccc" | replace("a", "x", 2) }}', 'xxabbbccc');


### PR DESCRIPTION
The `select` and `reject` filters from Jinja rely on the concept of "tests", which nunjucks doesn't have. But `selectattr` and `rejectattr` are quite useful, and the single-argument version of them does not rely on tests.