### PR TITLE
Fix error when template is not found

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -149,9 +149,8 @@ var Environment = Obj.extend({
 
             lib.asyncIter(this.loaders, function(loader, i, next, done) {
                 function handle(src) {
-                    src.loader = loader;
-
                     if(src) {
+                        src.loader = loader;
                         done(src);
                     }
                     else {


### PR DESCRIPTION
This is a fix for an error I introduced in my precedent PR (Sorry ...).

I'm currently running some tests for GitBook on Windows and Nunjucks is not working there (tests are all failing).
You should maybe consider using Appveyor (as simple as travis and free for open source projects) to test Nunjucks on Windows.
I'll take a deep look at why Nunjucks is not working (it's reason why GitBook is not working).