### PR TITLE
fix watching in node-loader

### DIFF
--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -31,6 +31,7 @@ var FileSystemLoader = Loader.extend({
                     var watcher = chokidar.watch(p, { ignoreInitial: true });
 
                     watcher.on('all', function(event, fullname) {
+                        fullname = path.resolve(fullname);
                         if(event === 'change' && fullname in this.pathsToNames) {
                             this.emit('update', this.pathsToNames[fullname]);
                         }


### PR DESCRIPTION
@SamyPesse The relative templates broke watching. In `getSource` the `fullpath` key in `pathsToNames` is now always fully absolute, but in the watcher the path it gets is still just a relative path. I think this fixes it, but can you verify?

Are you not using the watcher?