### PR TITLE
Fix nunjucks for windows: relative paths and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-
-test:
-	node_modules/.bin/istanbul cover node_modules/.bin/_mocha \
-		-- -b -R tap tests
-
-browserfiles:
-	./bin/bundle browser/nunjucks
-	SLIM=1 ./bin/bundle browser/nunjucks-slim

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
   matrix:
     - nodejs_version: "0.11"
     - nodejs_version: "0.10"
-    - nodejs_version: "0.8"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autocrlf input
+
+# Test against these versions of Node.js.
+environment:
+  matrix:
+    - nodejs_version: "0.11"
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.8"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "node": "*"
     },
     "scripts": {
-        "test": "make test"
+        "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -b -R tap tests",
+        "browserfiles": "./bin/bundle browser/nunjucks; SLIM=1 ./bin/bundle browser/nunjucks-slim"
     },
     "bin": {
         "nunjucks-precompile": "./bin/precompile"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "node": "*"
     },
     "scripts": {
-        "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -b -R tap tests",
+        "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -b -R tap tests",
         "browserfiles": "./bin/bundle browser/nunjucks; SLIM=1 ./bin/bundle browser/nunjucks-slim"
     },
     "bin": {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -124,7 +124,7 @@ var Compiler = Object.extend({
     },
 
     _templateName: function() {
-        return this.templateName == null? 'undefined' : '"'+this.templateName.replace(/"/g, '\\"')+'"';
+        return this.templateName == null? 'undefined' : JSON.stringify(this.templateName);
     },
 
     _bufferAppend: function(func) {

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -37,6 +37,27 @@ function precompile(input, opts) {
 
     var pathStats = fs.existsSync(input) && fs.statSync(input);
     var output = '';
+    var templates = [];
+
+    function addTemplates(dir) {
+        var files = fs.readdirSync(dir);
+
+        for(var i=0; i<files.length; i++) {
+            var filepath = path.join(dir, files[i]);
+            var subpath = filepath.substr(path.join(input, '/').length);
+            var stat = fs.statSync(filepath);
+
+            if(stat && stat.isDirectory()) {
+                subpath += '/';
+                if (!match(subpath, opts.exclude)) {
+                    addTemplates(filepath);
+                }
+            }
+            else if(match(subpath, opts.include)) {
+                templates.push(filepath);
+            }
+        }
+    }
 
     if(opts.isString) {
         if(!opts.name) {
@@ -56,28 +77,6 @@ function precompile(input, opts) {
                            opts.asFunction);
     }
     else if(pathStats.isDirectory()) {
-        var templates = [];
-
-        function addTemplates(dir) {
-            var files = fs.readdirSync(dir);
-
-            for(var i=0; i<files.length; i++) {
-                var filepath = path.join(dir, files[i]);
-                var subpath = filepath.substr(path.join(input, '/').length);
-                var stat = fs.statSync(filepath);
-
-                if(stat && stat.isDirectory()) {
-                    subpath += '/';
-                    if (!match(subpath, opts.exclude)) {
-                        addTemplates(filepath);
-                    }
-                }
-                else if(match(subpath, opts.include)) {
-                    templates.push(filepath);
-                }
-            }
-        }
-
         addTemplates(input);
 
         for(var i=0; i<templates.length; i++) {

--- a/tests/api.js
+++ b/tests/api.js
@@ -1,11 +1,13 @@
 (function() {
     'use strict';
 
-    var expect, Environment, Loader, templatesPath;
+    var expect, util, Environment, Loader, templatesPath;
     var path = require('path');
+    var os = require('os');
 
     if(typeof require !== 'undefined') {
         expect = require('expect.js');
+        util = require('./util');
         Environment = require('../src/environment').Environment;
         Loader = require('../src/node-loaders').FileSystemLoader;
         templatesPath = 'tests/templates';
@@ -41,7 +43,7 @@
 
             var test = env.getTemplate('relative/test-cache.html');
 
-            expect(test.render()).to.be('Test1\nTest2');
+            expect(util.normEOL(test.render())).to.be('Test1\nTest2');
         });
 
         it('should handle correctly relative paths in renderString', function() {

--- a/tests/precompile.js
+++ b/tests/precompile.js
@@ -1,0 +1,22 @@
+(function() {
+    'use strict';
+
+    var expect, precompile, precompileString;
+
+    if(typeof require !== 'undefined') {
+        expect = require('expect.js');
+        precompile = require('../src/precompile').precompile;
+        precompileString = require('../src/precompile').precompileString;
+    }
+    else {
+        expect = window.expect;
+        precompile = nunjucks.precompile;
+        precompileString = nunjucks.precompileString
+    }
+
+    describe('precompile', function() {
+        it('should return a string', function() {
+            expect(precompileString("{{ test }}", { name: "test.html" })).to.be.an('string');
+        });
+    });
+})();

--- a/tests/util.js
+++ b/tests/util.js
@@ -54,7 +54,7 @@
 
     function normEOL(str) {
         if (!str) return str;
-        return str.replace(/\r\n|\r|\n/g, "\n");
+        return str.replace(/\r\n|\r/g, "\n");
     }
 
     function render(str, ctx, opts, cb) {

--- a/tests/util.js
+++ b/tests/util.js
@@ -54,7 +54,7 @@
 
     function normEOL(str) {
         if (!str) return str;
-        return str.replace("\r\n", "\n");
+        return str.replace(/\r\n|\r|\n/g, "\n");
     }
 
     function render(str, ctx, opts, cb) {

--- a/tests/util.js
+++ b/tests/util.js
@@ -52,6 +52,11 @@
         }
     }
 
+    function normEOL(str) {
+        if (!str) return str;
+        return str.replace("\r\n", "\n");
+    }
+
     function render(str, ctx, opts, cb) {
         if(!opts) {
             cb = ctx;
@@ -95,7 +100,7 @@
                     throw err;
                 }
 
-                cb(err, res);
+                cb(err, normEOL(res));
 
                 doneAsyncs++;
 
@@ -110,12 +115,14 @@
         module.exports.render = render;
         module.exports.equal = equal;
         module.exports.finish = finish;
+        module.exports.normEOL = normEOL;
     }
     else {
         window.util = {
             render: render,
             equal: equal,
-            finish: finish
+            finish: finish,
+            normEOL: normEOL
         };
     }
 })();


### PR DESCRIPTION
The goals of this PR are:

- [x] Fix relative paths on Windows
- [x] Adapt tests for windows (some tests are using `\n` and on windows it's `\r\n`)
- [x] Maybe if you want to, adapt tests script to work with Appveyor