### PR TITLE
Add option to automatically indent blocks

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -954,12 +954,17 @@ var Compiler = Object.extend({
     },
 
     compileBlock: function(node, frame) {
-        if(!this.isChild) {
+        if(this.isChild) {
+            this.emitLine('if (!frame.hasOwnProperty("indent_' + node.name.value + '")) { frame["indent_' + node.name.value + '"] = ' + node.colno + '; }');
+        }
+        else {
             var id = this.tmpid();
 
             this.emitLine('context.getBlock("' + node.name.value + '")' +
                           '(env, context, frame, runtime, ' + this.makeCallback(id));
-            this.emitLine(this.buffer + ' += ' + id + ';');
+            this.emitLine('var indent = ' + node.colno + ' - (frame["indent_' + node.name.value + '"] || 1);');
+            this.emitLine('if (!frame.hasOwnProperty("indent_' + node.name.value + '")) { indent = 0; }');
+            this.emitLine(this.buffer + ' += runtime.formatBlock(' + id + ', indent, !env.opts.indentBlocks);');
             this.addScopeLevel();
         }
     },

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1006,6 +1006,7 @@ var Compiler = Object.extend({
     },
 
     compileInclude: function(node, frame) {
+        // console.log(node.colno);
         var id = this.tmpid();
         var id2 = this.tmpid();
 
@@ -1016,7 +1017,8 @@ var Compiler = Object.extend({
 
         this.emitLine(id + '.render(' +
                       'context.getVariables(), frame.push(), ' + this.makeCallback(id2));
-        this.emitLine(this.buffer + ' += ' + id2);
+        this.emitLine(this.buffer + ' += runtime.formatBlock(' + id2 + ', ' + (node.colno - 1) + ', !env.opts.indentBlocks);');
+
         this.addScopeLevel();
     },
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -32,6 +32,8 @@ var Environment = Obj.extend({
 
         this.opts.lstripBlocks = !!opts.lstripBlocks;
 
+        this.opts.indentBlocks = !!opts.indentBlocks;
+
         if(!loaders) {
             // The filesystem loader is only available client-side
             if(builtin_loaders.FileSystemLoader) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -320,6 +320,17 @@ function asyncAll(arr, dimen, func, cb) {
     }
 }
 
+function formatBlock(text, indentWidth, doNothing) {
+    if (doNothing) {
+        return text;
+    }
+    function indentLines(line, idx) {
+        return idx == 0 ? line : indent + line;
+    }
+    var indent = lib.repeat(' ', indentWidth);
+    return text.trim().split('\n').map(indentLines).join('\n');
+}
+
 module.exports = {
     Frame: Frame,
     makeMacro: makeMacro,
@@ -336,5 +347,6 @@ module.exports = {
     copySafeness: copySafeness,
     markSafe: markSafe,
     asyncEach: asyncEach,
-    asyncAll: asyncAll
+    asyncAll: asyncAll,
+    formatBlock: formatBlock
 };

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -663,6 +663,17 @@
             finish(done);
         });
 
+        it('should include templates with auto indentation', function(done) {
+            var opts = { indentBlocks: true };
+
+            render('<div>\n  {% include "include-multiline.html" %}\n</div>',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  foo\n    bar\n  baz\n</div>');
+                   });
+
+            finish(done);
+        });
+
         /**
          * This test checks that this issue is resolved: http://stackoverflow.com/questions/21777058/loop-index-in-included-nunjucks-file
          */

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -621,6 +621,48 @@
             finish(done);
         });
 
+        it('should render blocks with auto indentation', function(done) {
+            var opts = { indentBlocks: true };
+
+            render('{% extends "base-block-indent.html" %}\n' +
+                   '{% block A %}new_A{% endblock %}\n{% block B %}new_B{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  new_A\n\n  <p>\n    new_B\n  </p>\n</div>\n');
+                   });
+
+            render('{% extends "base-block-indent.html" %}\n' +
+                   '{% block A %}new_A1\nnew_A2{% endblock %}\n{% block B %}new_B1\n  new_B1.1\nnew_B2{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  new_A1\n  new_A2\n\n  <p>\n    new_B1\n      new_B1.1\n    new_B2\n  </p>\n</div>\n');
+                   });
+
+            render('{% extends "base-block-indent.html" %}\n' +
+                   '{% block A %}new_A1\nnew_A2{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  new_A1\n  new_A2\n\n  <p>\n    default_B\n  </p>\n</div>\n');
+                   });
+
+            render('{% extends "base-block-indent.html" %}\n' +
+                   '{% block B %}new_B1\n  new_B1.1\nnew_B2{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  default_A\n\n  <p>\n    new_B1\n      new_B1.1\n    new_B2\n  </p>\n</div>\n');
+                   });
+
+            render('{% extends "base-block-indent-2.html" %}\n' +
+                   '{% block B %}new_B1\n  new_B1.1\nnew_B2{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  replaced_A\n\n  <p>\n    new_B1\n      new_B1.1\n    new_B2\n  </p>\n</div>\n');
+                   });
+
+            render('{% extends "base-block-indent-2.html" %}\n' +
+                   '{% block C %}content_C{% endblock %}',
+                   null, opts, function (err, res) {
+                       expect(res).to.be('<div>\n  replaced_A\n\n  <p>\n    replaced_B1\n      content_C\n    replaced_B2\n  </p>\n</div>\n');
+                   });
+
+            finish(done);
+        });
+
         /**
          * This test checks that this issue is resolved: http://stackoverflow.com/questions/21777058/loop-index-in-included-nunjucks-file
          */

--- a/tests/templates/base-block-indent-2.html
+++ b/tests/templates/base-block-indent-2.html
@@ -1,0 +1,10 @@
+{% extends 'base-block-indent.html' %}
+{% block A %}
+replaced_A
+{% endblock %}
+
+  {% block B %}
+  replaced_B1
+    {% block C %}{% endblock %}
+  replaced_B2
+  {% endblock %}

--- a/tests/templates/base-block-indent.html
+++ b/tests/templates/base-block-indent.html
@@ -1,0 +1,11 @@
+<div>
+  {% block A %}
+  default_A
+  {% endblock %}
+
+  <p>
+    {% block B %}
+    default_B
+    {% endblock %}
+  </p>
+</div>

--- a/tests/templates/include-multiline.html
+++ b/tests/templates/include-multiline.html
@@ -1,0 +1,3 @@
+foo
+  bar
+baz


### PR DESCRIPTION
Since I care a lot about how the rendered markup of template looks, I have been trying to find a way to ensure that the indentation matches the original when extending a base template. This pull requests adds an option `indentBlocks` that does exactly that. As it compiles the templates, it will remember the indentation of blocks and automatically figure out how to indent the content of the blocks in extending templates to match the original indentation.

Since this might be undesired by some (not sure why though ;P), and since it actually broke a test (a *single* test—but only because of a trailing line ending that got removed), I made this option not a default. So people are free to decide whether they want this or not.

I’ve added tests that not only check the basic functionality but also ensure that it works when extending multiple levels of templates, or when definining a new block in an extending template that is then filled in a third level. The general rule is that the indentation of the block where it was originally defined decides about how the content is indented. For nested blocks, this is additive; for example in one test, there is a block `C` defined within the content of block `B` and the content `C` is indented for both `B` and `C`.

Here is a more simple example that shows how it works:

    <div>
      {% block A %}{% endblock %}
      <div>
         {% block B %}
         default content
         {% endblock %}
      </div>
    </div>

Example extending template:

    {% extends 'base.html' %}
    {% block A %}
    <h1>Example content</h1>
    {% endblock %}

    {% block B %}
    This content will have the original indentation.
    {% endblock %}

Above results in the following, which is nice and pretty:

    <div>
      <h1>Example content</h1>
      <div>
        This content will have the original indentation.
      </div>
    </div>

As for the implementation, I had to add the `formatBlocks` function somewhere where it was accessible from the compiled template code. I thought it was most fitting in the `runtime` module, at least compared to the other persistent alternatives (environment and context). For remembering the indentation, I used the `frame` object which luckily was not only persistent for the duration of the template execution but also was set up in a good order.

I originally tried to do the remembering and calculations directly in the compiler but unfortunately there wasn’t a way that allowed me to store the indentation state without making it completely global. This is because the `frame` object is only temporary for each block. So in the end, I had to put the logic into the compiled template code.

Any way, I think this turned out pretty nicely and it works pretty well for me, so I hope you will accept this change.