### PR TITLE
Makes length filter work with SafeString

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -150,8 +150,12 @@ var filters = {
         return arr[arr.length-1];
     },
 
-    length: function(arr) {
-        return arr !== undefined ? arr.length : 0;
+    length: function(val) {
+        var value = val;
+        if ( val instanceof r.SafeString )
+            value = val.valueOf();
+
+        return value !== undefined ? value.length : 0;
     },
 
     list: function(val) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -3,6 +3,21 @@
 var lib = require('./lib');
 var r = require('./runtime');
 
+
+var normalize = function(value, defaultValue) {
+
+    if (value === null || value === undefined) {
+        return defaultValue;
+    }
+
+    if (value instanceof r.SafeString) {
+        return normalize(value.valueOf(), defaultValue);
+    }
+
+    return value;
+};
+
+
 var filters = {
     abs: function(n) {
         return Math.abs(n);
@@ -35,11 +50,13 @@ var filters = {
     },
 
     capitalize: function(str) {
+        str = normalize(str, '');
         var ret = str.toLowerCase();
         return r.copySafeness(str, ret.charAt(0).toUpperCase() + ret.slice(1));
     },
 
     center: function(str, width) {
+        str = normalize(str, '');
         width = width || 80;
 
         if(str.length >= width) {
@@ -117,6 +134,10 @@ var filters = {
     },
 
     indent: function(str, width, indentfirst) {
+        str = normalize(str, '');
+
+        if (str === '') return '';
+
         width = width || 4;
         var res = '';
         var lines = str.split('\n');
@@ -151,9 +172,7 @@ var filters = {
     },
 
     length: function(val) {
-        var value = val;
-        if ( val instanceof r.SafeString )
-            value = val.valueOf();
+        var value = normalize(val, '');
 
         return value !== undefined ? value.length : 0;
     },
@@ -188,6 +207,7 @@ var filters = {
     },
 
     lower: function(str) {
+        str = normalize(str, '');
         return str.toLowerCase();
     },
 
@@ -212,7 +232,7 @@ var filters = {
             return str.replace(old, new_);
         }
 
-        var res = str;
+        var res = normalize(str, '');
         var last = res;
         var count = 1;
         res = res.replace(old, new_);
@@ -329,6 +349,7 @@ var filters = {
     },
 
     title: function(str) {
+        str = normalize(str, '');
         var words = str.split(' ');
         for(var i = 0; i < words.length; i++) {
             words[i] = filters.capitalize(words[i]);
@@ -342,6 +363,7 @@ var filters = {
 
     truncate: function(input, length, killwords, end) {
         var orig = input;
+        input = normalize(input, '');
         length = length || 255;
 
         if (input.length <= length)
@@ -363,6 +385,7 @@ var filters = {
     },
 
     upper: function(str) {
+        str = normalize(str, '');
         return str.toUpperCase();
     },
 
@@ -437,6 +460,7 @@ var filters = {
     },
 
     wordcount: function(str) {
+        str = normalize(str, '');
         var words = (str) ? str.match(/\w+/g) : null;
         return (words) ? words.length : null;
     },

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -1,17 +1,19 @@
 (function() {
     'use strict';
 
-    var expect, util, lib;
+    var expect, util, lib, r;
 
     if(typeof require !== 'undefined') {
         expect = require('expect.js');
         util = require('./util');
         lib = require('../src/lib');
+        r = require('../src/runtime');
     }
     else {
         expect = window.expect;
         util = window.util;
         lib = nunjucks.require('lib');
+        r = nunjucks.require('runtime');
     }
 
     var render = util.render;
@@ -39,6 +41,10 @@
 
         it('capitalize', function(done) {
             equal('{{ "foo" | capitalize }}', 'Foo');
+            equal('{{ str | capitalize }}', {str: r.markSafe('foo')}, 'Foo');
+            equal('{{ undefined | capitalize }}', '');
+            equal('{{ null | capitalize }}', '');
+            equal('{{ nothing | capitalize }}', '');
             finish(done);
         });
 
@@ -46,6 +52,23 @@
             equal('{{ "fooo" | center }}',
                   lib.repeat(' ', 38) + 'fooo' +
                   lib.repeat(' ', 38));
+
+            equal('{{ str | center }}', {str: r.markSafe('fooo')},
+                  lib.repeat(' ', 38) + 'fooo' +
+                  lib.repeat(' ', 38));
+
+            equal('{{ undefined | center }}',
+                  lib.repeat(' ', 40)+ '' +
+                  lib.repeat(' ', 40));
+
+            equal('{{ null | center }}',
+                  lib.repeat(' ', 40)+ '' +
+                  lib.repeat(' ', 40));
+
+            equal('{{ nothing | center }}',
+                  lib.repeat(' ', 40)+ '' +
+                  lib.repeat(' ', 40));
+
 
             equal('{{ "foo" | center }}',
                   lib.repeat(' ', 38) + 'foo' +
@@ -155,6 +178,22 @@
                   'one\n  two\n  three\n');
             equal('{{ "one\ntwo\nthree" | indent(2, true) }}',
                   '  one\n  two\n  three\n');
+
+            equal('{{ str | indent }}', {str: r.markSafe('one\ntwo\nthree')},
+                  'one\n    two\n    three\n');
+
+            equal('{{ "" | indent }}', '');
+            equal('{{ undefined | indent }}', '');
+            equal('{{ undefined | indent(2) }}','');
+            equal('{{ undefined | indent(2, true) }}','');
+
+            equal('{{ null | indent }}','');
+            equal('{{ null | indent(2) }}','');
+            equal('{{ null | indent(2, true) }}','');
+
+            equal('{{ nothing | indent }}','');
+            equal('{{ nothing | indent(2) }}','');
+            equal('{{ nothing | indent(2, true) }}','');
             finish(done);
         });
 
@@ -182,12 +221,12 @@
 
         it('length', function(done) {
             equal('{{ [1,2,3] | length }}', '3');
+            equal('{{ blah|length }}', '0');
+            equal('{{ str | length }}', {str:r.markSafe('blah')}, '4');
+            equal('{{ undefined | length }}', '0');
+            equal('{{ null | length }}', '0');
+            equal('{{ nothing | length }}', '0');
             finish(done);
-        });
-
-        it('length handle undefined variables', function(done) {
-          equal('{{ blah|length }}', '0');
-          finish(done);
         });
 
         it('list', function(done) {
@@ -202,6 +241,10 @@
 
         it('lower', function(done) {
             equal('{{ "fOObAr" | lower }}', 'foobar');
+            equal('{{ str | lower }}', {str: r.markSafe('fOObAr')}, 'foobar');
+            equal('{{ null | lower }}', '');
+            equal('{{ undefined | lower }}', '');
+            equal('{{ nothing | lower }}', '');
             finish(done);
         });
 
@@ -236,7 +279,7 @@
             equal('{{ "aaaAAA" | replace(r/a/i, "z") }}', 'zaaAAA');
             equal('{{ "aaaAAA" | replace(r/a/g, "z") }}', 'zzzAAA');
             equal('{{ "aaaAAA" | replace(r/a/gi, "z") }}', 'zzzzzz');
-
+            equal('{{ str | replace("a", "x") }}', {str: r.markSafe('aaabbbccc')}, 'xxxbbbccc');
             finish(done);
         });
 
@@ -307,11 +350,16 @@
 
         it('title', function(done) {
             equal('{{ "foo bar baz" | title }}', 'Foo Bar Baz');
+            equal('{{ str | title }}', {str: r.markSafe('foo bar baz')}, 'Foo Bar Baz');
+            equal('{{ undefined | title }}', '');
+            equal('{{ null | title }}', '');
+            equal('{{ nothing | title }}', '');
             finish(done);
         });
 
         it('trim', function(done) {
             equal('{{ "  foo " | trim }}', 'foo');
+            equal('{{ str | trim }}', {str: r.markSafe('  foo ')}, 'foo');
             finish(done);
         });
 
@@ -321,12 +369,35 @@
             equal('{{ "foo bar baz" | truncate(7) }}', 'foo bar...');
             equal('{{ "foo bar baz" | truncate(5, true) }}', 'foo b...');
             equal('{{ "foo bar baz" | truncate(6, true, "?") }}', 'foo ba?');
+            equal('{{ "foo bar" | truncate(3) }}', {str: r.markSafe('foo bar')}, 'foo...');
+
+            equal('{{ undefined | truncate(3) }}', '');
+            equal('{{ undefined | truncate(6) }}', '');
+            equal('{{ undefined | truncate(7) }}', '');
+            equal('{{ undefined | truncate(5, true) }}', '');
+            equal('{{ undefined | truncate(6, true, "?") }}', '');
+
+            equal('{{ null | truncate(3) }}', '');
+            equal('{{ null | truncate(6) }}', '');
+            equal('{{ null | truncate(7) }}', '');
+            equal('{{ null | truncate(5, true) }}', '');
+            equal('{{ null | truncate(6, true, "?") }}', '');
+
+            equal('{{ nothing | truncate(3) }}', '');
+            equal('{{ nothing | truncate(6) }}', '');
+            equal('{{ nothing | truncate(7) }}', '');
+            equal('{{ nothing | truncate(5, true) }}', '');
+            equal('{{ nothing | truncate(6, true, "?") }}', '');
 
             finish(done);
         });
 
         it('upper', function(done) {
             equal('{{ "foo" | upper }}', 'FOO');
+            equal('{{ str | upper }}', {str: r.markSafe('foo')}, 'FOO');
+            equal('{{ null | upper }}', '');
+            equal('{{ undefined | upper }}', '');
+            equal('{{ nothing | upper }}', '');
             finish(done);
         });
 
@@ -418,6 +489,10 @@
 
         it('wordcount', function(done) {
             equal('{{ "foo bar baz" | wordcount }}', '3');
+            equal('{{ str | wordcount }}', {str: r.markSafe('foo bar baz')},'3');
+            equal('{{ null | wordcount }}', '');
+            equal('{{ undefined | wordcount }}', '');
+            equal('{{ nothing | wordcount }}', '');
             finish(done);
         });
     });


### PR DESCRIPTION
The `length` filter does not work with `SafeString` because `SafeString` is an `Object`, not a `string` or an `array`.
This pull request adds a type check in the length filter, so that in the case of a SafeString object, the length of the underlying value is returned.

It would probably be cleaner to add a `length` property to the `SafeString` object (like it was in version 1.0.2 and previous), but since the `SafeString` object inherits from `String.prototype`, the `length` property is read-only. I couldn't find a clean way to work around this limitation, so I decided change the `length` filter directly instead.

I'm happy to help if someone has a better idea to solve this issue.