### PR TITLE
Update .npmignore due to the large size on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 node_modules
 coverage
+docs
+tests
+bench


### PR DESCRIPTION
Because the doc and tests, the package is really large.

Before

```
PKGFILES SUMMARY
Size on Disk with Dependencies  ~16.74 MB
Size with Dependencies          ~14.43 MB
Publishable Size                ~5.46 MB 
Number of Directories           308      
Number of Files                 308  
```

After

```
PKGFILES SUMMARY
Size on Disk with Dependencies  ~16.74 MB 
Size with Dependencies          ~14.43 MB 
Publishable Size                ~474.36 kB
Number of Directories           33        
Number of Files                 33    
```