### PR TITLE
add wrapper CLI option for loading a precompile plugin

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -36,6 +36,10 @@ var optimist = require('optimist')
         .default('exclude', [])
         .alias('x', 'exclude')
 
+    .describe('wrapper', 'Something something change')
+        .string('wrapper')
+        .alias('w', 'wrapper')
+
     .demand(1);
 
 var argv = optimist.argv;
@@ -51,13 +55,16 @@ lib.each([].concat(argv.filters).join(',').split(','), function(name) {
     env.addFilter(name.trim(), function() {}, true);
 });
 
-console.log(precompile(argv._[0], {
+if(argv.wrapper) {
+    argv.wrapper = require('nunjucks-' + argv.wrapper).wrapper;
+}
 
+console.log(precompile(argv._[0], {
     env : env,
     force : argv.force,
     name : argv.name,
+    wrapper: argv.wrapper,
 
     include : [].concat(argv.include),
     exclude : [].concat(argv.exclude)
-
 }));

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports.Template = env.Template;
 
 module.exports.Loader = Loader;
 module.exports.FileSystemLoader = loaders.FileSystemLoader;
+module.exports.PrecompiledLoader = loaders.PrecompiledLoader;
 module.exports.WebLoader = loaders.WebLoader;
 
 module.exports.compiler = compiler;

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -79,7 +79,24 @@ var FileSystemLoader = Loader.extend({
     }
 });
 
+var PrecompiledLoader = Loader.extend({
+    init: function(compiledTemplates) {
+        this.precompiled = compiledTemplates || {};
+    },
+
+    getSource: function(name) {
+        if (this.precompiled[name]) {
+            return {
+                src: { type: "code",
+                       obj: this.precompiled[name] },
+                path: name
+            };
+        }
+        return null;
+    }
+});
 
 module.exports = {
-    FileSystemLoader: FileSystemLoader
+    FileSystemLoader: FileSystemLoader,
+    PrecompiledLoader: PrecompiledLoader
 };


### PR DESCRIPTION
This is my replacement PR for #337. This allows you to specify a wrapper at the precompile CLI like `nunjucks-precompile -w cjs foo.html`, and it will `require` the module `nunjucks-cjs` and use the `wrapper` function is exports as the wrapper option. It can then wrap each template code however it likes.

This PR also adds a new loader that will take a bundle of precompiled templates in node and load them. Any wrapper can emit code to build up an object keyed off of template name and give it to this loader.