### PR TITLE
add "loose" option to default filter, add warning about change

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -702,13 +702,37 @@ If `tags` was `["food", "beer", "dessert"]`, the above example would output `foo
 
 ## Builtin Filters
 
-Nunjucks has ported most of jinja's filters (click through for documentation):
+Nunjucks has ported most of jinja's filters, and has a few of its own.
+We need to work on our own documentation for filters. Some of them are
+documented below, for the rest you can click through to jinja's site.
+
+### default(value, default, [loose])
+
+(aliased as `d`)
+
+If `value` is `null` or `undefined`, return `default`, otherwise
+`value`. If `loose` is true, any JavaScript falsy value will return
+`default` (false, "", etc)
+
+**In version 2.0, `loose` is required because this filter changed from
+  loose by default to strict by default. A warning will be display if
+  you don't specify loose, and once we've warned everyone of the
+  change we will remove the warning. If you are sure this change won't 
+  affect you, ignore this warning.**
+
+### sort(arr, reverse, caseSens, attr)
+
+Sort `arr` with JavaScript's `arr.sort` function. If `reverse` is
+true, result will be reversed. Sort is case-insensitive by default,
+but setting `caseSense` to true makes it case-sensitive. If `attr` is
+passed, will compare `attr` from each item.
+
+### More Filters
 
 * [abs](http://jinja.pocoo.org/docs/templates/#abs)
 * [batch](http://jinja.pocoo.org/docs/templates/#batch)
 * [capitalize](http://jinja.pocoo.org/docs/templates/#capitalize)
 * [center](http://jinja.pocoo.org/docs/templates/#center)
-* [default](http://jinja.pocoo.org/docs/templates/#default) (aliased as `d`)
 * [dictsort](http://jinja.pocoo.org/docs/templates/#dictsort)
 * [escape](http://jinja.pocoo.org/docs/templates/#escape) (aliased as `e`)
 * [safe](http://jinja.pocoo.org/docs/templates/#safe)
@@ -727,7 +751,6 @@ Nunjucks has ported most of jinja's filters (click through for documentation):
 * [round](http://jinja.pocoo.org/docs/templates/#round)
 * [selectattr](http://jinja.pocoo.org/docs/templates/#selectattr) (only the single-argument form)
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)
-* [sort](http://jinja.pocoo.org/docs/templates/#sort)
 * [string](http://jinja.pocoo.org/docs/templates/#string)
 * [title](http://jinja.pocoo.org/docs/templates/#title)
 * [trim](http://jinja.pocoo.org/docs/templates/#trim)

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -706,12 +706,12 @@ Nunjucks has ported most of jinja's filters, and has a few of its own.
 We need to work on our own documentation for filters. Some of them are
 documented below, for the rest you can click through to jinja's site.
 
-### default(value, default, [loose])
+### default(value, default, [boolean])
 
 (aliased as `d`)
 
-If `value` is `null` or `undefined`, return `default`, otherwise
-`value`. If `loose` is true, any JavaScript falsy value will return
+If `value` is strictly `undefined`, return `default`, otherwise
+`value`. If `boolean` is true, any JavaScript falsy value will return
 `default` (false, "", etc)
 
 **In version 2.0, `loose` is required because this filter changed from

--- a/src/filters.js
+++ b/src/filters.js
@@ -10,6 +10,7 @@ function normalize(value, defaultValue) {
     return value;
 }
 
+var hasWarnedDefault = false;
 
 var filters = {
     abs: function(n) {
@@ -63,8 +64,24 @@ var filters = {
         return r.copySafeness(str, pre + str + post);
     },
 
-    'default': function(val, def) {
-        return val ? val : def;
+    'default': function(val, def, loose) {
+        if(loose !== true || loose !== false && !hasWarnedDefault) {
+            hasWarnedDefault = true;
+            console.log(
+                '[nunjucks] Warning: the "default" filter was used without ' +
+                'specifying the loose/strict behavior. This is required for this '+
+                'version because "default" used to be loose (val ? val : def) ' +
+                'but is now strict (only checks for null/undefined). ' +
+                'See http://mozilla.github.io/nunjucks/templating.html#defaultvalue-default-loose'
+            );
+        }
+
+        if(loose) {
+            return val ? val : def;
+        }
+        else {
+            return (val !== null && val !== undefined) ? val : def;
+        }
     },
 
     dictsort: function(val, case_sensitive, by) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -64,23 +64,24 @@ var filters = {
         return r.copySafeness(str, pre + str + post);
     },
 
-    'default': function(val, def, loose) {
-        if(loose !== true || loose !== false && !hasWarnedDefault) {
+    'default': function(val, def, bool) {
+        if(bool !== true && bool !== false && !hasWarnedDefault) {
             hasWarnedDefault = true;
             console.log(
                 '[nunjucks] Warning: the "default" filter was used without ' +
-                'specifying the loose/strict behavior. This is required for this '+
-                'version because "default" used to be loose (val ? val : def) ' +
-                'but is now strict (only checks for null/undefined). ' +
+                'specifying the type of comparison. 2.0 changed the default ' +
+                'behavior from boolean (val ? val : def) to strictly undefined, ' +
+                'so you should make sure that doesn\'t break anything. ' +
+                'Be explicit about this to make this warning go away, or wait until 2.1. ' +
                 'See http://mozilla.github.io/nunjucks/templating.html#defaultvalue-default-loose'
             );
         }
 
-        if(loose) {
+        if(bool) {
             return val ? val : def;
         }
         else {
-            return (val !== null && val !== undefined) ? val : def;
+            return (val !== undefined) ? val : def;
         }
     },
 

--- a/tests/express-sample/views/index.html
+++ b/tests/express-sample/views/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-Hello, {{ username }}! This is just some content.
+Hello, {{ username | default('poop') }}! This is just some content.
 
 <div id="dynamic"></div>
 {% endblock %}

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -76,6 +76,8 @@
         });
 
         it('default', function(done) {
+            equal('{{ undefined | default("foo") }}', 'foo');
+            equal('{{ bar | default("foo") }}', { bar: null }, '');
             equal('{{ false | default("foo") }}', 'false');
             equal('{{ false | default("foo", true) }}', 'foo');
             equal('{{ bar | default("foo") }}', 'foo');

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -76,7 +76,9 @@
         });
 
         it('default', function(done) {
-            equal('{{ false | default("foo") }}', 'foo');
+            equal('{{ false | default("foo") }}', 'false');
+            equal('{{ false | default("foo", true) }}', 'foo');
+            equal('{{ bar | default("foo") }}', 'foo');
             equal('{{ "bar" | default("foo") }}', 'bar');
             finish(done);
         });


### PR DESCRIPTION
@carljm how does this look? I basically warn people about the change and tell them to check their filters. if they are sure it's not going to affect them they can ignore the warning.

I also am not checking specifically for `false` when it is "loose", but any falsy JS value will return the default. Is that sane?

That's the kind if thing that might differ under a "jinja" compat mode... truthiness is the hardest thing to reconcile.