### PR TITLE
Added bundle option to precompiled wrappers

### DIFF
--- a/src/precompile-global.js
+++ b/src/precompile-global.js
@@ -1,19 +1,23 @@
 'use strict';
 
-function precompileGlobal(name, template, opts) {
+function precompileGlobal(templates, opts) {
+    var out = '', name, template;
     opts = opts || {};
 
-    name = JSON.stringify(name);
+    for ( var i = 0; i < templates.length; i++ ) {
+        name = JSON.stringify(templates[i].name);
+        template = templates[i].template;
 
-    var out = '(function() {' +
-        '(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})' +
-        '[' + name + '] = (function() {\n' + template + '\n})();\n';
+        out += '(function() {' +
+            '(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})' +
+            '[' + name + '] = (function() {\n' + template + '\n})();\n';
 
-    if(opts.asFunction) {
-        out += 'return function(ctx, cb) { return nunjucks.render(' + name + ', ctx, cb); }\n';
+        if(opts.asFunction) {
+            out += 'return function(ctx, cb) { return nunjucks.render(' + name + ', ctx, cb); }\n';
+        }
+
+        out += '})();\n';
     }
-
-    out += '})();\n';
     return out;
 }
 

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -107,8 +107,8 @@ function precompile(input, opts) {
         }
     }
 
-    if (wrapper.hasOwnProperty('bundle')) {
-        output = wrapper.bundle(output);
+    if (wrapper.hasOwnProperty('postProcess')) {
+        output = wrapper.postProcess(output);
     }
 
     return output;

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -69,14 +69,14 @@ function precompile(input, opts) {
                             'compiling a string');
         }
 
-        return _precompile(wrapper,
+        output = _precompile(wrapper,
                            input,
                            opts.name,
                            env,
                            opts);
     }
     else if(pathStats.isFile()) {
-        return _precompile(wrapper,
+        output = _precompile(wrapper,
                            fs.readFileSync(input, 'utf-8'),
                            opts.name || input,
                            env,
@@ -105,9 +105,13 @@ function precompile(input, opts) {
                 }
             }
         }
-
-        return output;
     }
+
+    if (wrapper.hasOwnProperty('bundle')) {
+        output = wrapper.bundle(output);
+    }
+
+    return output;
 }
 
 function _precompile(wrapper, str, name, env, opts) {

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -40,7 +40,7 @@ function precompile(input, opts) {
     var wrapper = opts.wrapper || precompileGlobal;
 
     var pathStats = fs.existsSync(input) && fs.statSync(input);
-    var output = '';
+    var precompiled = [];
     var templates = [];
 
     function addTemplates(dir) {
@@ -69,18 +69,18 @@ function precompile(input, opts) {
                             'compiling a string');
         }
 
-        output = _precompile(wrapper,
-                           input,
-                           opts.name,
-                           env,
-                           opts);
+        precompiled.push( _precompile(
+            input,
+            opts.name,
+            env
+        ) );
     }
     else if(pathStats.isFile()) {
-        output = _precompile(wrapper,
-                           fs.readFileSync(input, 'utf-8'),
-                           opts.name || input,
-                           env,
-                           opts);
+        precompiled.push( _precompile(
+            fs.readFileSync(input, 'utf-8'),
+            opts.name || input,
+            env
+        ) );
     }
     else if(pathStats.isDirectory()) {
         addTemplates(input);
@@ -89,11 +89,11 @@ function precompile(input, opts) {
             var name = templates[i].replace(path.join(input, '/'), '');
 
             try {
-                output += _precompile(wrapper,
-                                      fs.readFileSync(templates[i], 'utf-8'),
-                                      name,
-                                      env,
-                                      opts);
+                precompiled.push( _precompile(
+                    fs.readFileSync(templates[i], 'utf-8'),
+                    name,
+                    env
+                ) );
             } catch(e) {
                 if(opts.force) {
                     // Don't stop generating the output if we're
@@ -107,14 +107,10 @@ function precompile(input, opts) {
         }
     }
 
-    if (wrapper.hasOwnProperty('postProcess')) {
-        output = wrapper.postProcess(output);
-    }
-
-    return output;
+    return wrapper(precompiled, opts);
 }
 
-function _precompile(wrapper, str, name, env, opts) {
+function _precompile(str, name, env) {
     env = env || new Environment([]);
 
     var asyncFilters = env.asyncFilters;
@@ -132,7 +128,7 @@ function _precompile(wrapper, str, name, env, opts) {
         throw lib.prettifyError(name, false, err);
     }
 
-    return wrapper(name, template, opts);
+    return { name: name, template: template };
 }
 
 module.exports = {


### PR DESCRIPTION
Hello!

I was writing wrappers for the major module formats, but with ES6 I had some difficulty. For named exports, the names must be valid variable identifiers. So I couldn't simply export the template name, because it might contain slashes, dashes, etc, so I had to create a plain old JS object to export as default.

But as the file might contain many templates inside, I'd have to create a check for the existence of this object on each template. Instead, I created this PR to be able to create the object once and export it once.