### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,7 @@
     "template",
     "templating"
   ],
-  "license": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/mozilla/nunjucks/blob/master/LICENSE"
-    }
-  ],
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/mozilla/nunjucks/issues"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/