### PR TITLE
Added Jinja2 style express string concatenation with tests

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -175,6 +175,7 @@ var Compiler = Object.extend({
             nodes.Or,
             nodes.Not,
             nodes.Add,
+            nodes.Concat,
             nodes.Sub,
             nodes.Mul,
             nodes.Div,
@@ -370,6 +371,9 @@ var Compiler = Object.extend({
     compileOr: binOpEmitter(' || '),
     compileAnd: binOpEmitter(' && '),
     compileAdd: binOpEmitter(' + '),
+    // ensure concatenation instead of addition
+    // by adding empty string in between
+    compileConcat: binOpEmitter(' + "" + '),
     compileSub: binOpEmitter(' - '),
     compileMul: binOpEmitter(' * '),
     compileDiv: binOpEmitter(' / '),

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -3,7 +3,7 @@
 var lib = require('./lib');
 
 var whitespaceChars = ' \n\t\r\u00A0';
-var delimChars = '()[]{}%*-+/#,:|.<>=!';
+var delimChars = '()[]{}%*-+~/#,:|.<>=!';
 var intChars = '0123456789';
 
 var BLOCK_START = '{%';
@@ -30,6 +30,7 @@ var TOKEN_RIGHT_CURLY = 'right-curly';
 var TOKEN_OPERATOR = 'operator';
 var TOKEN_COMMA = 'comma';
 var TOKEN_COLON = 'colon';
+var TOKEN_TILDE = 'tilde';
 var TOKEN_PIPE = 'pipe';
 var TOKEN_INT = 'int';
 var TOKEN_FLOAT = 'float';
@@ -169,6 +170,7 @@ Tokenizer.prototype.nextToken = function() {
             case '}': type = TOKEN_RIGHT_CURLY; break;
             case ',': type = TOKEN_COMMA; break;
             case ':': type = TOKEN_COLON; break;
+            case '~': type = TOKEN_TILDE; break;
             case '|': type = TOKEN_PIPE; break;
             default: type = TOKEN_OPERATOR;
             }
@@ -459,6 +461,7 @@ module.exports = {
     TOKEN_OPERATOR: TOKEN_OPERATOR,
     TOKEN_COMMA: TOKEN_COMMA,
     TOKEN_COLON: TOKEN_COLON,
+    TOKEN_TILDE: TOKEN_TILDE,
     TOKEN_PIPE: TOKEN_PIPE,
     TOKEN_INT: TOKEN_INT,
     TOKEN_FLOAT: TOKEN_FLOAT,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -128,6 +128,7 @@ var Or = BinOp.extend('Or');
 var And = BinOp.extend('And');
 var Not = UnaryOp.extend('Not');
 var Add = BinOp.extend('Add');
+var Concat = BinOp.extend('Concat');
 var Sub = BinOp.extend('Sub');
 var Mul = BinOp.extend('Mul');
 var Div = BinOp.extend('Div');
@@ -281,6 +282,7 @@ module.exports = {
     And: And,
     Not: Not,
     Add: Add,
+    Concat: Concat,
     Sub: Sub,
     Mul: Mul,
     Div: Div,

--- a/src/parser.js
+++ b/src/parser.js
@@ -747,7 +747,7 @@ var Parser = Object.extend({
 
     parseCompare: function() {
         var compareOps = ['==', '!=', '<', '>', '<=', '>='];
-        var expr = this.parseAdd();
+        var expr = this.parseConcat();
         var ops = [];
 
         while(1) {
@@ -759,7 +759,7 @@ var Parser = Object.extend({
             else if(lib.indexOf(compareOps, tok.value) !== -1) {
                 ops.push(new nodes.CompareOperand(tok.lineno,
                                                   tok.colno,
-                                                  this.parseAdd(),
+                                                  this.parseConcat(),
                                                   tok.value));
             }
             else {
@@ -777,6 +777,19 @@ var Parser = Object.extend({
         else {
             return expr;
         }
+    },
+
+    // finds the '~' for string concatenation
+    parseConcat: function(){
+        var node = this.parseAdd();
+        while(this.skipValue(lexer.TOKEN_TILDE, '~')) {
+            var node2 = this.parseAdd();
+            node = new nodes.Concat(node.lineno,
+                                 node.colno,
+                                 node,
+                                 node2);
+        }
+        return node;
     },
 
     parseAdd: function() {

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -387,6 +387,13 @@
             finish(done);
         });
 
+        it('should compile string concatenations with tilde', function(done){
+            equal('{{ 4 ~ \'hello\' }}', '4hello');
+            equal('{{ 4 ~ 5 }}', '45');
+            equal('{{ \'a\' ~ \'b\' ~ 5 }}', 'ab5');
+            finish(done);
+        });
+
         it('should compile macros', function(done) {
             equal('{% macro foo() %}This is a macro{% endmacro %}' +
                   '{{ foo() }}',

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -235,6 +235,17 @@
                       [nodes.Symbol, 'y']]]]]);
         });
 
+        it('should parse tilde', function(){
+            isAST(parser.parse('{{ 2 ~ 3 }}'),
+              [nodes.Root,
+               [nodes.Output,
+                [nodes.Concat,
+                  [nodes.Literal, 2],
+                  [nodes.Literal, 3]
+                ]]]
+              );
+        });
+
         it('should parse operators with correct precedence', function() {
             isAST(parser.parse('{{ x in y and z }}'),
                   [nodes.Root,


### PR DESCRIPTION
Nunjucks is missing the Jinja2 '~' which expressly concatenates irrespective of source type unlike the javascript '+' which performs an addition between any numbers