### PR TITLE
test definition of global macros from within a simple include file

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -466,6 +466,14 @@
             finish(done);
         });
 
+        it('should allow definition of global macros in an included file', function(done) {
+          equal('{% include "include-macro.html" %}' +
+            '{{ foo("test") }}',
+            'testtest'
+          );
+          finish(done);
+        });
+
         it('should compile call blocks', function(done) {
           equal('{% macro wrap(el) %}' +
                 '<{{ el }}>{{ caller() }}</{{ el }}>' +

--- a/tests/templates/include-macro.html
+++ b/tests/templates/include-macro.html
@@ -1,0 +1,1 @@
+{% macro foo(bar) %}bar bar{% endmacro %}

--- a/tests/templates/include-macro.html
+++ b/tests/templates/include-macro.html
@@ -1,1 +1,1 @@
-{% macro foo(bar) %}bar bar{% endmacro %}
+{%- macro foo(bar) %}{{ bar }}{{ bar }}{% endmacro -%}


### PR DESCRIPTION
This test currently fails with this error:

Error: Unable to call `foo`, which is undefined or falsey