### PR TITLE
Add new filter: contains

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -534,11 +534,33 @@ var filters = {
     'int': function(val, def) {
         var res = parseInt(val, 10);
         return isNaN(res) ? def : res;
+    },
+
+    contains: function(container, item) {
+        if (container instanceof Array) {
+            for (var index = 0; index < container.length; index++) {
+                if (container[index] === item) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (typeof container === 'object') {
+            return container[item] !== undefined;
+        }
+
+        if (typeof container === 'string') {
+            return container.indexOf(item) !== -1;
+        }
+
+        throw new lib.TemplateError('contains filter: container is not understood');
     }
 };
 
 // Aliases
 filters.d = filters['default'];
 filters.e = filters.escape;
+filters.has = filters.contains;
 
 module.exports = filters;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -538,5 +538,17 @@
             equal('{{ nothing | wordcount }}', '');
             finish(done);
         });
+
+        it('contains', function(done) {
+            equal('{{ ["foo", "bar"] | contains("foo") }}', 'true');
+            equal('{{ ["foo"] | contains("bar") }}', 'false');
+            equal('{{ [undefined] | contains(undefined) }}', 'true');
+            equal('{{ [null] | contains(null) }}', 'true');
+            equal('{{ { foo: "bar" } | contains("foo") }}', 'true');
+            equal('{{ { foo: null } | contains("bar") }}', 'false');
+            equal('{{ "foo bar" | contains("bar") }}', 'true');
+            equal('{{ "foo bar" | contains("baz") }}', 'false');
+            finish(done);
+        });
     });
 })();


### PR DESCRIPTION
```
contains(container, item)
```
Return `true` if the container contains the item. Otherwise `false`.

If the container is an Array, the function loops through the container comparing each element with the item using `===`, until the item is found or all elements are compared, whichever comes first.

If the container is an Object, the function checks if `container[item]` is **not** `undefined`.

If the container is a String, the function uses `String.prototype.indexOf` to find the item.

Finally, if the container is of any other type, the function throws a `TemplateError`.

The function has an alias, namely, `has`.

Issue: forfutureLLC/nunjucks#2

Any suggestions?