### PR TITLE
Respect explicitly-set undefined or null values in a frame.

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -466,6 +466,24 @@
             finish(done);
         });
 
+        it('should respect macro arg default value of none, not fallback to context', function(done) {
+            equal('{% macro foo(arg=none) %}{{ arg or "none" }}{% endmacro %}' +
+                  '{{ foo() }}',
+                  {arg: 'hey'},
+                  'none');
+
+            finish(done);
+        });
+
+        it('should respect macro arg default value of none, not fallback to frame', function(done) {
+            equal('{% macro inner(class=none) %}Class {{ class }}{% endmacro %}' +
+                  '{% macro outer(class=none) %}Class {{ class }}: {{ caller() }}{% endmacro %}' +
+                  '{% call outer(class="outer") %}{{ inner() }}{% endcall %}',
+                  'Class outer: Class ');
+
+            finish(done);
+        });
+
         it('should compile call blocks', function(done) {
           equal('{% macro wrap(el) %}' +
                 '<{{ el }}>{{ caller() }}</{{ el }}>' +


### PR DESCRIPTION
This fixes #478, which is a nasty subtle bug that leads to very strange and difficult-to-diagnose behaviors in calling template macros with arguments whose default value is `none`.

The core of the problem is nunjucks' loose handling of `null` and `undefined` in symbol value lookups. Symbol values are looked up at runtime using `contextOrFrameLookup`. If the frame lookup returns `null` or `undefined`, `contextOrFrameLookup` considers that a "not found" and looks up the name in the context instead. Similarly, with stacked frames, if an `undefined` or `null` value is found for the name in one frame, it ignores that and goes up to the parent frame instead. This means that you effectively cannot have a variable explicitly set to a value of `undefined` or `null` in a scope - if a parent scope (frame or context) has some other value for that symbol name, it will be used instead.

This pull request changes that behavior to instead use `hasOwnProperty` to determine whether a variable is present in a given frame or not, and never go up the frame stack (or fall back to context) if the variable is present, regardless of its value.

(If #480 is accepted, this PR could be changed to still consider `undefined` the same as "not found", but support `null`. That would be enough to support variables being set to `none`, which is really the motivating use case here.)