### PR TITLE
Update web-loaders.js

### DIFF
--- a/src/web-loaders.js
+++ b/src/web-loaders.js
@@ -5,7 +5,7 @@ var PrecompiledLoader = require('./precompiled-loader.js');
 
 var WebLoader = Loader.extend({
     init: function(baseURL, opts) {
-        this.baseURL = baseURL || '';
+        this.baseURL = baseURL || '.';
 
         // By default, the cache is turned off because there's no way
         // to "watch" templates over HTTP, so they are re-downloaded


### PR DESCRIPTION
As declared in API docs (http://mozilla.github.io/nunjucks/api.html#webloader) baseURL is the URL to load templates from (must be the same domain), and it defaults to the current relative directory. But up to now it defaults to domain root. This is an update to ensure that it worked as expected.