### PR TITLE
Copysafeness handling undefined & null gracefully

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -176,7 +176,9 @@ function copySafeness(dest, target) {
     if(dest instanceof SafeString) {
         return new SafeString(target);
     }
-    return target.toString();
+    var type = typeof target;
+    return type !== 'undefined' && type !== 'null' ?
+        target.toString() : '';
 }
 
 function markSafe(val) {


### PR DESCRIPTION
This is a simple fix that will not throw and error when an ```undefined``` or ```null``` is passed into the ```runtime.copySafeness()``` method.

Instead of an error, an empty string will be passed back. To use issue #471 as an example:
```javascript
var template = 'Hello {{firstName | string}} {{middleName | replace(',', ' ')}}{{lastName | string}}';
nunjucks.renderString(template, {
  firstName: 'Sammy',
  lastName: 'Jones'
});
// before - Error Thrown
// after - 'Hello Sammy Jones'
```