### PR TITLE
Add more APIs to manage extensions of environement

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -228,7 +228,7 @@ env.addFilter(name, func, [async])
 
 Add a custom filter named **name** which calls **func** whenever
 invoked. If the filter needs to be async, **async** must be `true`
-(see [asynchronous support](#asynchronous-support)). See 
+(see [asynchronous support](#asynchronous-support)). See
 [Custom Filters](#custom-filters).
 
 {% endapi %}
@@ -250,9 +250,23 @@ See [Custom Tags](#custom-tags).
 {% endapi %}
 
 {% api %}
+removeExtension
+env.removeExtension(name)
+
+Remove a previously added custom extension named **name**
+
+{% endapi %}
+
+{% api %}
 getExtension
 env.getExtension(name)
 Get an extension named **name**.
+{% endapi %}
+
+{% api %}
+hasExtension
+env.hasExtension(name)
+Return true if a custom extension named **name** as been added.
 {% endapi %}
 
 {% api %}
@@ -444,7 +458,7 @@ MyLoader.prototype.getSource = function(name) {
 It can get a little more complex. If you want to track updates to
 templates and bust the internal cache so that you can see updates, you
 need to extend the `Loader` class. This gives you `emit` method that
-can fire events. You need to call it 
+can fire events. You need to call it
 
 ```js
 var MyLoader = nunjucks.Loader.extend({
@@ -453,7 +467,7 @@ var MyLoader = nunjucks.Loader.extend({
         // and call `this.emit('update', name)` when a template
         // is changed
     }
-    
+
     getSource: function(name) {
         // load the template
     }
@@ -474,7 +488,7 @@ asynchronously.
 ```js
 var MyLoader = nunjucks.Loader.extend({
     async: true,
-    
+
     getSource: function(name, callback) {
         // load the template
         // ...

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,7 +253,7 @@ See [Custom Tags](#custom-tags).
 removeExtension
 env.removeExtension(name)
 
-Remove a previously added custom extension named **name**
+Remove a previously added custom extension named **name**.
 
 {% endapi %}
 
@@ -266,7 +266,7 @@ Get an extension named **name**.
 {% api %}
 hasExtension
 env.hasExtension(name)
-Return true if a custom extension named **name** as been added.
+Return true if a custom extension named **name** has been added.
 {% endapi %}
 
 {% api %}

--- a/src/environment.js
+++ b/src/environment.js
@@ -111,6 +111,10 @@ var Environment = Obj.extend({
         return this.extensions[name];
     },
 
+    hasExtension: function(name) {
+        return !!this.extensions[name];
+    },
+
     addGlobal: function(name, value) {
         globals[name] = value;
     },

--- a/src/environment.js
+++ b/src/environment.js
@@ -99,6 +99,14 @@ var Environment = Obj.extend({
         this.extensionsList.push(extension);
     },
 
+    removeExtension: function(name) {
+        var extension = this.getExtension(name);
+        if (!extension) return;
+
+        this.extensionsList.remove(extension);
+        delete this.extensions[name];
+    },
+
     getExtension: function(name) {
         return this.extensions[name];
     },

--- a/src/environment.js
+++ b/src/environment.js
@@ -103,7 +103,7 @@ var Environment = Obj.extend({
         var extension = this.getExtension(name);
         if (!extension) return;
 
-        this.extensionsList.remove(extension);
+        this.extensionsList = lib.without(this.extensionsList, extension);
         delete this.extensions[name];
     },
 


### PR DESCRIPTION
This is PR is just adding 2 methods to the Environment class: `removeExtension` and `hasExtension`.

I needed these methods for GitBook,  where some “blocks” can be redefined and the previous nunjucks extension needs to be cleanup before.