### PR TITLE
Add chaining of env 'add' methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 master (unreleased)
 -------------------
 
+* Add support for chaining of addGlobal, addFilter, etc. Thanks Rob Graeber. Merge of
+  [#537](https://github.com/mozilla/nunjucks/pull/537)
 * Fix error propagation. Thanks Tom Delmas. Merge of
   [#534](https://github.com/mozilla/nunjucks/pull/534).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -228,7 +228,7 @@ env.addFilter(name, func, [async])
 
 Add a custom filter named **name** which calls **func** whenever
 invoked. If the filter needs to be async, **async** must be `true`
-(see [asynchronous support](#asynchronous-support)). See
+(see [asynchronous support](#asynchronous-support)). Returns `env` for further method chaining. See
 [Custom Filters](#custom-filters).
 
 {% endapi %}
@@ -244,7 +244,7 @@ addExtension
 env.addExtension(name, ext)
 
 Add the custom extension **ext** named **name**. **ext** is an object
-with a few specific methods that are called by the extension system.
+with a few specific methods that are called by the extension system. Returns `env` for further method chaining.
 See [Custom Tags](#custom-tags).
 
 {% endapi %}
@@ -272,7 +272,8 @@ Return true if a custom extension named **name** has been added.
 {% api %}
 addGlobal
 env.addGlobal(name, value)
-Add a global value that will be available to all templates. Note: this will overwrite any existing global called `name`.
+Add a global value that will be available to all templates. Note: this will overwrite any existing global called `name`. 
+Returns `env` for further method chaining.
 {% endapi %}
 
 {% api %}
@@ -309,7 +310,7 @@ env.express(app)
 Install nunjucks as the rendering engine for the express **app**.
 After doing this, you can use express normally. Note that you can do
 this automatically with the simple API call [`configure`](#configure)
-by passing in the app as the **express** option.
+by passing in the app as the **express** option. Returns `env` for further method chaining.
 
 ```js
 var app = express();

--- a/src/environment.js
+++ b/src/environment.js
@@ -97,6 +97,7 @@ var Environment = Obj.extend({
         extension._name = name;
         this.extensions[name] = extension;
         this.extensionsList.push(extension);
+        return this;
     },
 
     removeExtension: function(name) {
@@ -117,6 +118,7 @@ var Environment = Obj.extend({
 
     addGlobal: function(name, value) {
         globals[name] = value;
+        return this;
     },
 
     getGlobal: function(name) {
@@ -133,6 +135,7 @@ var Environment = Obj.extend({
             this.asyncFilters.push(name);
         }
         this.filters[name] = wrapped;
+        return this;
     },
 
     getFilter: function(name) {
@@ -267,6 +270,7 @@ var Environment = Obj.extend({
         };
 
         app.set('view', NunjucksView);
+        return this;
     },
 
     render: function(name, ctx, cb) {
@@ -348,6 +352,7 @@ var Context = Obj.extend({
     addBlock: function(name, block) {
         this.blocks[name] = this.blocks[name] || [];
         this.blocks[name].push(block);
+        return this;
     },
 
     getBlock: function(name) {

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -84,6 +84,21 @@
           finish(done);
         });
 
+        it('should allow chaining of globals', function(done) {
+          var env = new Environment(new Loader(templatesPath));
+
+          env.addGlobal('hello', function(arg1) {
+            return 'Hello ' + arg1;
+          }).addGlobal('goodbye', function(arg1) {
+            return 'Goodbye ' + arg1;
+          });
+
+          equal('{{ hello("World!") }}', 'Hello World!');
+          equal('{{ goodbye("World!") }}', 'Goodbye World!');
+
+          finish(done);
+        });
+
         it('should allow getting of globals', function(done) {
             var env = new Environment(new Loader(templatesPath));
             var hello = function(arg1) {


### PR DESCRIPTION
As discussed in https://github.com/mozilla/nunjucks/issues/485, adds chaining for env 'add' methods like `addGlobal, addFilter, addBlock, etc`. I also wrote a test for addGlobal chaining and verified all the tests still pass. Let me know if you want anything improved.

@devoidfury @jlongster @carljm 

This would make chaining like this possible:
```
Nunjucks.configure(templateDir, {
    autoescape: true,
    trimBlocks: true,
    lstripBlocks: true,
    express: app
}).addGlobal('func1', function(arg) {
    return 'asdf'
}).addGlobal('func2', function(arg) {
    return 'asdf'
}).addGlobal('func3', function(arg) {
    return 'asdf'
}).addGlobal('func4', function(arg) {
    return 'asdf'
});
```