### PR TITLE
Fixed sudden "Cannot read property '...'  of undefined"

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -175,6 +175,7 @@ var Environment = Obj.extend({
 
         for (var i = 0; i < this.loaders.length; i++) {
             var _name = this.resolveTemplate(this.loaders[i], parentName, name);
+            if(!this.loaders[i].cache) this.loaders[i].cache = {};
             tmpl = this.loaders[i].cache[_name];
             if (tmpl) break;
         }


### PR DESCRIPTION
Without this line I always have an exception:
TypeError: Cannot read property '<name of html template>' of undefined
    at Obj.extend.getTemplate (/Users/.../node_modules/nunjucks/src/environment.js:179:41)
    at Obj.extend.render (/Users/.../node_modules/nunjucks/src/environment.js:289:14)
    at Object.module.exports.render (/Users/.../node_modules/nunjucks/index.js:71:14)
...
