### PR TITLE
Removed deprecation warning for default filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 master (unreleased)
 -------------------
 
+* Remove deprecation warning when using the `default` filter without specifying a third argument. Merge of
+  [#567](https://github.com/mozilla/nunjucks/pull/567).
 * Add support for chaining of addGlobal, addFilter, etc. Thanks Rob Graeber. Merge of
   [#537](https://github.com/mozilla/nunjucks/pull/537)
 * Fix error propagation. Thanks Tom Delmas. Merge of

--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -761,9 +761,7 @@ Si `value` est strictement `undefined`, cela retourne `default`, sinon
   Auparavant, il agissait comme si `boolean` était à true par défaut et donc toute
   valeur fausse retournait `default`. Dans la 2.0, le comportement par défaut retourne
   `default` seulement pour une valeur `undefined`. Vous pouvez obtenir l'ancien
-  comportement en passant `true` à `boolean`, ou en utilisant simplement `value or default`.
-  La 2.0 affichera un avertissement si `boolean` n'est pas passé, mais nous allons supprimer
-  cet avertissement dans la prochaine version.**
+  comportement en passant `true` à `boolean`, ou en utilisant simplement `value or default`.**
 
 ### sort(arr, reverse, caseSens, attr)
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -760,9 +760,7 @@ If `value` is strictly `undefined`, return `default`, otherwise
   filter. Previously, it acted as if `boolean` was true by default,
   and any falsy value would return `default`. In 2.0 the default is
   only an `undefined` value returns `default`. You can get the old
-  behavior by passing `true` to `boolean`, or just use `value or default`.
-  2.0 will show a warning if `boolean` is not passed, but we will remove 
-  this warning in the next version.**
+  behavior by passing `true` to `boolean`, or just use `value or default`.**
 
 ### sort(arr, reverse, caseSens, attr)
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -10,8 +10,6 @@ function normalize(value, defaultValue) {
     return value;
 }
 
-var hasWarnedDefault = false;
-
 var filters = {
     abs: function(n) {
         return Math.abs(n);
@@ -65,18 +63,6 @@ var filters = {
     },
 
     'default': function(val, def, bool) {
-        if(bool !== true && bool !== false && !hasWarnedDefault) {
-            hasWarnedDefault = true;
-            console.log(
-                '[nunjucks] Warning: the "default" filter was used without ' +
-                'specifying the type of comparison. 2.0 changed the default ' +
-                'behavior from boolean (val ? val : def) to strictly undefined, ' +
-                'so you should make sure that doesn\'t break anything. ' +
-                'Be explicit about this to make this warning go away, or wait until 2.1. ' +
-                'See http://mozilla.github.io/nunjucks/templating.html#defaultvalue-default-boolean'
-            );
-        }
-
         if(bool) {
             return val ? val : def;
         }


### PR DESCRIPTION
This is a PR for #566.

Removes the deprecation warning, and updates the documentation to reflect the changes.