### PR TITLE
Escape should not escape and mangle already escaped html entities

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -11,7 +11,7 @@ var escapeMap = {
     '>': '&gt;'
 };
 
-var escapeRegex = /[&"'<>]/g;
+var escapeRegex = /&(?!amp;|lt;|gt;|quot;|#39;)|["'<>]/g;
 
 var lookupEscape = function(ch) {
     return escapeMap[ch];

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -86,8 +86,8 @@
         });
 
         it('escape', function(done) {
-            var res = render('{{ "<html>" | escape }}', {}, { autoescape: false });
-            expect(res).to.be('&lt;html&gt;');
+            var res = render('{{ "<html> \' \\" &amp; &lt;html&gt; &quot; &#39;" | escape }}', {}, { autoescape: false });
+            expect(res).to.be('&lt;html&gt; &#39; &quot; &amp; &lt;html&gt; &quot; &#39;');
             finish(done);
         });
 


### PR DESCRIPTION
Consider that we are have already escaped text like:

`test &#39; &quot; &lt; &gt; &amp;`

In the browser it will look like

test &#39; &quot; &lt; &gt; &amp;

Escape will change all those & to `&amp;` and you will see

test &amp;#39; &amp;quot; &amp;lt; &amp;gt; &amp;amp;

Because the text is now

`test &amp;#39; &amp;quot; &amp;lt; &amp;gt; &amp;amp;`

Since auto escape is the default I think this behavior is bad.

I changed the regex so it doesn't do that, but its probably not the most efficient or correct way to do it.