### PR TITLE
Make each nunjucks environment have its own globals property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 master (unreleased)
 -------------------
 
+* Fix issue with different nunjucks environments sharing same globals. Each environment is now independent.
+  Thanks Paul Pechin. Merge of [#574](https://github.com/mozilla/nunjucks/pull/574).
 * Remove deprecation warning when using the `default` filter without specifying a third argument. Merge of
   [#567](https://github.com/mozilla/nunjucks/pull/567).
 * Add support for chaining of addGlobal, addFilter, etc. Thanks Rob Graeber. Merge of

--- a/src/globals.js
+++ b/src/globals.js
@@ -34,34 +34,39 @@ function joiner(sep) {
     };
 }
 
-var globals = {
-    range: function(start, stop, step) {
-        if(!stop) {
-            stop = start;
-            start = 0;
-            step = 1;
+// Making this a function instead so it returns a new object
+// each time it's called. That way, if something like an environment
+// uses it, they will each have their own copy.
+function globals() {
+    return {
+        range: function(start, stop, step) {
+            if(!stop) {
+                stop = start;
+                start = 0;
+                step = 1;
+            }
+            else if(!step) {
+                step = 1;
+            }
+
+            var arr = [];
+            for(var i=start; i<stop; i+=step) {
+                arr.push(i);
+            }
+            return arr;
+        },
+
+        // lipsum: function(n, html, min, max) {
+        // },
+
+        cycler: function() {
+            return cycler(Array.prototype.slice.call(arguments));
+        },
+
+        joiner: function(sep) {
+            return joiner(sep);
         }
-        else if(!step) {
-            step = 1;
-        }
-
-        var arr = [];
-        for(var i=start; i<stop; i+=step) {
-            arr.push(i);
-        }
-        return arr;
-    },
-
-    // lipsum: function(n, html, min, max) {
-    // },
-
-    cycler: function() {
-        return cycler(Array.prototype.slice.call(arguments));
-    },
-
-    joiner: function(sep) {
-        return joiner(sep);
-    }
-};
+    };
+}
 
 module.exports = globals;

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -79,7 +79,7 @@
             return 'Hello ' + arg1;
           });
 
-          equal('{{ hello("World!") }}', 'Hello World!');
+          equal('{{ hello("World!") }}', 'Hello World!', env);
 
           finish(done);
         });
@@ -93,8 +93,8 @@
             return 'Goodbye ' + arg1;
           });
 
-          equal('{{ hello("World!") }}', 'Hello World!');
-          equal('{{ goodbye("World!") }}', 'Goodbye World!');
+          equal('{{ hello("World!") }}', 'Hello World!', env);
+          equal('{{ goodbye("World!") }}', 'Goodbye World!', env);
 
           finish(done);
         });
@@ -115,7 +115,8 @@
         it('should fail on getting non-existent global', function(done) {
             var env = new Environment(new Loader(templatesPath));
 
-            expect(env.getGlobal).withArgs('hello1').to.throwError();
+            // Using this format instead of .withArgs since env.getGlobal uses 'this'
+            expect(function() { env.getGlobal('hello') }).to.throwError();
 
             finish(done);
         });
@@ -127,8 +128,21 @@
                 return 'Hello ' + this.lookup('user');
             });
 
-            equal('{{ hello() }}', { user: 'James' }, 'Hello James');
+            equal('{{ hello() }}', { user: 'James' }, 'Hello James', env);
             finish(done);
+        });
+
+        it('should be exclusive to each environment', function(done) {
+          var env = new Environment(new Loader(templatesPath));
+          var env2;
+
+          env.addGlobal('hello', 'konichiwa');
+          env2 = new Environment(new Loader(templatesPath));
+
+          // Using this format instead of .withArgs since env2.getGlobal uses 'this'
+          expect(function() { env2.getGlobal('hello') }).to.throwError();
+
+          finish(done);
         });
     });
 })();

--- a/tests/util.js
+++ b/tests/util.js
@@ -26,13 +26,14 @@
         doneHandler = null;
     });
 
-    function equal(str, ctx, str2) {
+    function equal(str, ctx, str2, env) {
         if(typeof ctx === 'string') {
+            env = str2;
             str2 = ctx;
             ctx = null;
         }
 
-        var res = render(str, ctx, {});
+        var res = render(str, ctx, {}, env);
         expect(res).to.be(str2);
     }
 
@@ -50,20 +51,26 @@
         return str.replace(/\r\n|\r/g, '\n');
     }
 
-    function render(str, ctx, opts, cb) {
+    function render(str, ctx, opts, env, cb) {
         if(typeof ctx === 'function') {
             cb = ctx;
             ctx = null;
             opts = null;
+            env = null;
         }
         else if(typeof opts === 'function') {
             cb = opts;
             opts = null;
+            env = null;
+        }
+        else if(typeof env === 'function') {
+            cb = env;
+            env = null;
         }
 
         opts = opts || {};
         opts.dev = true;
-        var e = new Environment(new Loader(templatesPath), opts);
+        var e = env || new Environment(new Loader(templatesPath), opts);
 
         var name;
         if(opts.filters) {


### PR DESCRIPTION
This is for the shared globals between environments issue mentioned in https://github.com/mozilla/nunjucks/issues/573. Let me know if you'd like me to revise anything.

Here's what's included:
- Added a test case.
- Updated test/util.js's equal method to take in an optional env parameter, since globals aren't shared between environments anymore.
- Updated Context in src/environment.js to take in an optional env parameter, for same reason.

Thanks!