### PR TITLE
Add negative steps support for range function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 master (unreleased)
 -------------------
 
+* Add negative steps support for range function
 * Remove deprecation warning when using the `default` filter without specifying a third argument. Merge of
   [#567](https://github.com/mozilla/nunjucks/pull/567).
 * Add support for chaining of addGlobal, addFilter, etc. Thanks Rob Graeber. Merge of

--- a/src/globals.js
+++ b/src/globals.js
@@ -46,8 +46,15 @@ var globals = {
         }
 
         var arr = [];
-        for(var i=start; i<stop; i+=step) {
-            arr.push(i);
+        var i;
+        if (step > 0) {
+            for (i=start; i<stop; i+=step) {
+                arr.push(i);
+            }
+        } else {
+            for (i=start; i>stop; i+=step) {
+                arr.push(i);
+            }
         }
         return arr;
     },

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -32,8 +32,8 @@
             equal('{% for i in range(5, 10, 2.5) %}{{ i }}{% endfor %}', '57.5');
             equal('{% for i in range(5, 10, 2.5) %}{{ i }}{% endfor %}', '57.5');
 
-            //equal('{% for i in range(5, 10, -1) %}{{ i }}{% endfor %}', '56789');
-            //equal('{% for i in range(5, 10, -1 | abs) %}{{ i }}{% endfor %}','56789');
+            equal('{% for i in range(10, 5, -1) %}{{ i }}{% endfor %}', '109876');
+            equal('{% for i in range(10, 5, -2.5) %}{{ i }}{% endfor %}', '107.5');
 
             finish(done);
         });


### PR DESCRIPTION
In current version:
```
range(10, 5, -1) // -> []
```

With this PR: 
```
range(10, 5, -1) // -> [10, 9, 8 ,7 ,6]
```