### PR TITLE
Fix #516 by exposing "dev" not in "env.opts" but "env" itself

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -31,7 +31,7 @@ var Environment = Obj.extend({
         //  the library)
         // defaults to false
         opts = this.opts = opts || {};
-        this.opts.dev = !!opts.dev;
+        this.dev = !!opts.dev;
 
         // The autoescape flag sets global autoescaping. If true,
         // every string variable will be escaped by default.

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -755,6 +755,19 @@
             finish(done);
         });
 
+        it('should include meaningful stack trace when dev options is set true', function(done) {
+            render(
+                '{% include "missing.html" %}',
+                {},
+                { noThrow: true },
+                function(err) {
+                    expect(err.stack.split('\n')[2]).to.match(/at createTemplate/);
+                }
+            );
+
+            finish(done);
+        });
+
         it('should fail silently on missing templates if requested', function(done) {
             equal('hello world {% include "missing.html" ignore missing %}',
                   'hello world ');


### PR DESCRIPTION
because it is used like this + a test. Not sure about tests. Maybe there is more elegant way to test that. I just took previous test and used it's stacktrace