### PR TITLE
Add striptags filter

### DIFF
--- a/docs/cn/templating.md
+++ b/docs/cn/templating.md
@@ -634,6 +634,7 @@ Nunjucks 已经支持了大部分 jinja 的过滤器 (点击查看文档)。
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)
 * [sort](http://jinja.pocoo.org/docs/templates/#sort)
 * [string](http://jinja.pocoo.org/docs/templates/#string)
+* [striptags](http://jinja.pocoo.org/docs/templates/#striptags)
 * [title](http://jinja.pocoo.org/docs/templates/#title)
 * [trim](http://jinja.pocoo.org/docs/templates/#trim)
 * [truncate](http://jinja.pocoo.org/docs/templates/#truncate)

--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -809,6 +809,7 @@ passé, cela permettra de comparer `attr` à chaque élément.
 * [selectattr](http://jinja.pocoo.org/docs/templates/#selectattr) (seulement pour le formulaire avec un unique argument)
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)
 * [string](http://jinja.pocoo.org/docs/templates/#string)
+* [striptags](http://jinja.pocoo.org/docs/templates/#striptags)
 * [title](http://jinja.pocoo.org/docs/templates/#title)
 * [trim](http://jinja.pocoo.org/docs/templates/#trim)
 * [truncate](http://jinja.pocoo.org/docs/templates/#truncate)

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -809,6 +809,7 @@ passed, will compare `attr` from each item.
 * [selectattr](http://jinja.pocoo.org/docs/templates/#selectattr) (only the single-argument form)
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)
 * [string](http://jinja.pocoo.org/docs/templates/#string)
+* [striptags](http://jinja.pocoo.org/docs/templates/#striptags)
 * [title](http://jinja.pocoo.org/docs/templates/#title)
 * [trim](http://jinja.pocoo.org/docs/templates/#trim)
 * [truncate](http://jinja.pocoo.org/docs/templates/#truncate)

--- a/src/filters.js
+++ b/src/filters.js
@@ -398,6 +398,12 @@ var filters = {
         return r.copySafeness(obj, obj);
     },
 
+    striptags: function(input) {
+        input = normalize(input, '');
+        var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>|<!--[\s\S]*?-->/gi;
+        return r.copySafeness(input, filters.trim(input.replace(tags, '')).replace(/\s+/gi, ' '));
+    },
+
     title: function(str) {
         str = normalize(str, '');
         var words = str.split(' ');

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -394,6 +394,20 @@
             finish(done);
         });
 
+        it('striptags', function(done) {
+            equal('{{ html | striptags }}', {html: '<foo>bar'}, 'bar');
+            equal('{{ html | striptags }}',
+                  {
+                      html: '  <p>an  \n <a href="#">example</a> link</p>\n<p>to a webpage</p> ' +
+                            '<!-- <p>and some comments</p> -->'
+                  },
+                  'an example link to a webpage');
+            equal('{{ undefined | striptags }}', '');
+            equal('{{ null | striptags }}', '');
+            equal('{{ nothing | striptags }}', '');
+            finish(done);
+        });
+
         it('title', function(done) {
             equal('{{ "foo bar baz" | title }}', 'Foo Bar Baz');
             equal('{{ str | title }}', {str: r.markSafe('foo bar baz')}, 'Foo Bar Baz');


### PR DESCRIPTION
I migrated from swig to nunjucks and realized there was no striptags filter. There is already an opened issue : #359

One of the tests is very similar to [this one (from jinja)](https://github.com/mitsuhiko/jinja2/blob/master/tests/test_filters.py#L68-L73)