### PR TITLE
Build browser bundles with a UMD wrapper.

### DIFF
--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -35,7 +35,8 @@ var config = {
     output: {
         path: path.join(__dirname, '../browser'),
         filename: TARGET,
-        library: 'nunjucks'
+        library: 'nunjucks',
+        libraryTarget: 'umd'
     },
     node: {
         process: 'empty'


### PR DESCRIPTION
Fixes https://github.com/mozilla/nunjucks/issues/507, replacing https://github.com/mozilla/nunjucks/pull/556.

Note that this should be considered a breaking change, at least for people who were using the ``exports-loader`` to expose the ``nunjucks`` var before.