### PR TITLE
chokidar on demand

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,7 @@ directory, and the following options are available in **opts**:
 * **trimBlocks** *(default: false)* automatically remove trailing newlines from a block/tag
 * **lstripBlocks** *(default: false)* automatically remove leading whitespace from a block/tag
 * **watch** *(default: false)* reload templates when they are changed (server-side)
+    If using watch, ensure chokidar is installed first: `$ npm i chokidar`
 * **noCache** *(default: false)* never use a cache and recompile templates each time (server-side)
 * **web** an object for configuring loading templates in the browser:
   * **useCache** *(default: false)* will enable cache and templates will never see updates.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "author": "James Long <longster@gmail.com>",
   "dependencies": {
     "asap": "^2.0.3",
-    "chokidar": "^1.0.0",
     "optimist": "*"
+  },
+  "optionalDependencies": {
+    "chokidar": "^1.0.0"
   },
   "browser": "./browser/nunjucks.js",
   "devDependencies": {

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 var lib = require('./lib');
 var Loader = require('./loader');
-var chokidar = require('chokidar');
 var PrecompiledLoader = require('./precompiled-loader.js');
 
 // Node <0.7.1 compatibility
@@ -34,8 +33,8 @@ var FileSystemLoader = Loader.extend({
         }
 
         if(opts.watch) {
-            // Watch all the templates in the paths and fire an event when
-            // they change
+            var chokidar = require('chokidar');
+            // Watch all the templates in the paths and fire an event when they change
             var paths = this.searchPaths.filter(function(p) { return existsSync(p); });
             var watcher = chokidar.watch(paths);
             var _this = this;


### PR DESCRIPTION
- make chokidar an optional dependency
- only require chokidar when `{ watch: true }`
- if chokidar is not installed and `{ watch: true }`, notify the user with a console error (but don't fail)

Fixes #600 