### PR TITLE
UMD precompiled

### DIFF
--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -35,7 +35,8 @@ var config = {
     output: {
         path: path.join(__dirname, '../browser'),
         filename: TARGET,
-        library: 'nunjucks'
+        library: 'nunjucks',
+        libraryTarget: 'umd'
     },
     node: {
         process: 'empty'

--- a/src/environment.js
+++ b/src/environment.js
@@ -11,6 +11,9 @@ var runtime = require('./runtime');
 var globals = require('./globals');
 var Frame = runtime.Frame;
 var Template;
+// Set the root for global variables (precompiled templates export to this)
+var root = typeof window === 'object' ? window : GLOBAL;
+
 
 // Unconditionally load in this loader, even if no other ones are
 // included (possible in the slim browser build)
@@ -63,9 +66,9 @@ var Environment = Obj.extend({
         // It's easy to use precompiled templates: just include them
         // before you configure nunjucks and this will automatically
         // pick it up and use it
-        if(process.env.IS_BROWSER && window.nunjucksPrecompiled) {
+        if(root.nunjucksPrecompiled) {
             this.loaders.unshift(
-                new builtin_loaders.PrecompiledLoader(window.nunjucksPrecompiled)
+                new builtin_loaders.PrecompiledLoader(root.nunjucksPrecompiled)
             );
         }
 

--- a/src/precompile-global.js
+++ b/src/precompile-global.js
@@ -4,20 +4,52 @@ function precompileGlobal(templates, opts) {
     var out = '', name, template;
     opts = opts || {};
 
-    for ( var i = 0; i < templates.length; i++ ) {
-        name = JSON.stringify(templates[i].name);
-        template = templates[i].template;
+    out += '// nunjucks precompiled templates\n';
+    out += '(function (root, factory) {\n' +
+        '\tif (typeof define === \'function\' && define.amd) {\n' +
+            '\t\t// AMD. Register as a named module.\n' +
+            '\t\tdefine(\'nunjucksPrecompiled\', [], function () {\n' +
+                '\t\t\treturn (root.nunjucksPrecompiled = factory());\n' +
+            '\t\t});\n' +
+        '\t} else if (typeof module === \'object\' && module.exports) {\n' +
+            '\t\t// Node. Does not work with strict CommonJS,\n' +
+            '\t\t// but only CommonJS-like environments that support module.exports, like Node.\n' +
+            '\t\tGLOBAL.nunjucksPrecompiled = factory();\n' +
+        '\t} else {\n' +
+            '\t\t// Browser globals\n' +
+            '\t\troot.nunjucksPrecompiled = factory();\n' +
+        '\t}\n' +
+    '}(this, function () {\n' +
+            '\treturn {\n';
+            for ( var i = 0; i < templates.length; i++ ) {
+                name = JSON.stringify(templates[i].name);
+                template = templates[i].template;
 
-        out += '(function() {' +
-            '(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})' +
-            '[' + name + '] = (function() {\n' + template + '\n})();\n';
+                out += '\n\t\t// Begin template ' + name + '\n';
+                out += '\t\t' + name + ': (function() {\n' + template + '\n})()';
+                if (i < templates.length - 1) {
+                    out += ',';
+                }
+                out += '\n\t\t// End of template ' + name + '\n';
+            }
+            out += '\n\t};\n' +
+    '}));';
 
-        if(opts.asFunction) {
-            out += 'return function(ctx, cb) { return nunjucks.render(' + name + ', ctx, cb); }\n';
-        }
-
-        out += '})();\n';
-    }
+    // TODO: Reinstate the opt.asFunction logic
+    // TODO: Remove the commented out original code below when opts.asFunction is complete
+    //for ( var i = 0; i < templates.length; i++ ) {
+    //    name = JSON.stringify(templates[i].name);
+    //
+    //    out += '(function() {' +
+    //        '(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})' +
+    //        '[' + name + '] = (function() {\n' + template + '\n})();\n';
+    //
+    //    if(opts.asFunction) {
+    //        out += 'return function(ctx, cb) { return nunjucks.render(' + name + ', ctx, cb); }\n';
+    //    }
+    //
+    //    out += '})();\n';
+    //}
     return out;
 }
 


### PR DESCRIPTION
**THIS IS NOT READY TO MERGE**

#608 

Convert precompiled templates to use a UMD wrapper instead of `window.nunjucksPrecompiled`, this is a step towards making a true UMD compatible nunjucks-slim version:

- In browser, compiled templates are attached to `window.nunjucksPrecompiled`
- In an AMD environment, `nunjucksPrecompiled` is a named module
- in node, compiled templates are attached to `GLOBAL.nunjucksPrecompiled`

The generated browser files are not included in this commit to keep the source changes obvious - `npm run browserfiles` to generate them.