### PR TITLE
Add optional "preserve linebreaks" behavior for `striptags` filter

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -784,6 +784,14 @@ true, result will be reversed. Sort is case-insensitive by default,
 but setting `caseSens` to true makes it case-sensitive. If `attr` is
 passed, will compare `attr` from each item.
 
+### striptags (value, [preserve_linebreaks])
+
+Analog of jinja's [striptags](http://jinja.pocoo.org/docs/templates/#striptags). If `preserve_linebreaks` is false (default),
+strips SGML/XML tags and replaces adjacent whitespace with one space.
+If `preserve_linebreaks` is true, normalizes whitespace, trying to preserve original
+linebreaks. Use second behavior if you want to pipe
+`{{ text | striptags | nl2br }}`. Use default one otherwise.
+
 ### More Filters
 
 * [abs](http://jinja.pocoo.org/docs/templates/#abs)
@@ -809,7 +817,6 @@ passed, will compare `attr` from each item.
 * [selectattr](http://jinja.pocoo.org/docs/templates/#selectattr) (only the single-argument form)
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)
 * [string](http://jinja.pocoo.org/docs/templates/#string)
-* [striptags](http://jinja.pocoo.org/docs/templates/#striptags)
 * [title](http://jinja.pocoo.org/docs/templates/#title)
 * [trim](http://jinja.pocoo.org/docs/templates/#trim)
 * [truncate](http://jinja.pocoo.org/docs/templates/#truncate)

--- a/src/filters.js
+++ b/src/filters.js
@@ -406,11 +406,12 @@ var filters = {
         if (preserve_linebreaks) {
             res = filters.trim(input.replace(tags, ''))
                 .replace(/^ +| +$/gm, '')     // remove leading and trailing spaces
-                .replace(/ +/g, ' ')          // squash consequent spaces
+                .replace(/ +/g, ' ')          // squash adjacent spaces
                 .replace(/(\r\n)/g, '\n')     // normalize linebreaks (CRLF -> LF)
-                .replace(/\n\n\n+/g, '\n\n'); // squash abnormal consequent linebreaks
+                .replace(/\n\n\n+/g, '\n\n'); // squash abnormal adjacent linebreaks
         } else {
-            res = filters.trim(input.replace(tags, '')).replace(/\s+/gi, ' ');
+            res = filters.trim(input.replace(tags, ''))
+                .replace(/\s+/gi, ' ');
         }
         return r.copySafeness(input, res);
     },

--- a/src/filters.js
+++ b/src/filters.js
@@ -402,16 +402,16 @@ var filters = {
         input = normalize(input, '');
         preserve_linebreaks = preserve_linebreaks || false;
         var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>|<!--[\s\S]*?-->/gi;
+        var trimmedInput = filters.trim(input.replace(tags, ''));
         var res = '';
         if (preserve_linebreaks) {
-            res = filters.trim(input.replace(tags, ''))
+            res = trimmedInput
                 .replace(/^ +| +$/gm, '')     // remove leading and trailing spaces
                 .replace(/ +/g, ' ')          // squash adjacent spaces
                 .replace(/(\r\n)/g, '\n')     // normalize linebreaks (CRLF -> LF)
                 .replace(/\n\n\n+/g, '\n\n'); // squash abnormal adjacent linebreaks
         } else {
-            res = filters.trim(input.replace(tags, ''))
-                .replace(/\s+/gi, ' ');
+            res = trimmedInput.replace(/\s+/gi, ' ');
         }
         return r.copySafeness(input, res);
     },

--- a/src/filters.js
+++ b/src/filters.js
@@ -398,10 +398,21 @@ var filters = {
         return r.copySafeness(obj, obj);
     },
 
-    striptags: function(input) {
+    striptags: function(input, preserve_linebreaks) {
         input = normalize(input, '');
+        preserve_linebreaks = preserve_linebreaks || false;
         var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>|<!--[\s\S]*?-->/gi;
-        return r.copySafeness(input, filters.trim(input.replace(tags, '')).replace(/\s+/gi, ' '));
+        var res = '';
+        if (preserve_linebreaks) {
+            res = filters.trim(input.replace(tags, ''))
+                .replace(/^ +| +$/gm, '')     // remove leading and trailing spaces
+                .replace(/ +/g, ' ')          // squash consequent spaces
+                .replace(/(\r\n)/g, '\n')     // normalize linebreaks (CRLF -> LF)
+                .replace(/\n\n\n+/g, '\n\n'); // squash abnormal consequent linebreaks
+        } else {
+            res = filters.trim(input.replace(tags, '')).replace(/\s+/gi, ' ');
+        }
+        return r.copySafeness(input, res);
     },
 
     title: function(str) {

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -405,6 +405,12 @@
             equal('{{ undefined | striptags }}', '');
             equal('{{ null | striptags }}', '');
             equal('{{ nothing | striptags }}', '');
+            equal('{{ html | striptags(true) }}',
+                  {
+                      html: '<div>\n  row1\nrow2  \n  <strong>row3</strong>\n</div>\n\n' +
+                            ' HEADER \n\n<ul>\n  <li>option  1</li>\n<li>option  2</li>\n</ul>'
+                  },
+                  'row1\nrow2\nrow3\n\nHEADER\n\noption 1\noption 2');
             finish(done);
         });
 


### PR DESCRIPTION
It's often desired to pipe `{{ text | striptags | nl2br }}`.
For example, when we're rendering email template from feedback form.
This commit adds an option to remove tags, keeping significant whitespace.

`{{ text | striptags(true) | nl2br }}` 

This converts a messy
```html
# HEADER      1    
<div>
  row1
row2
  <strong>row3</strong>
</div>

     ## HEADER 2

      <ul>
        <li>option 1</li>
        <li>option 2</li>
        <li>option 3</li>
      </ul>
```

to a human-readable form
```
# HEADER 1

row1
row2
row3

## HEADER 2

option 1
option 2
option 3
```