### PR TITLE
docs for 'wrapper' option of the precompile API

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -6,7 +6,7 @@ var lib = require('../src/lib');
 
 var optimist = require('optimist')
 
-    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] <path>')
+    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-w|--wrapper <wrapper>] <path>')
     .wrap(80)
 
     .describe('help', 'Display this help message')
@@ -36,7 +36,7 @@ var optimist = require('optimist')
         .default('exclude', [])
         .alias('x', 'exclude')
 
-    .describe('wrapper', 'Something something change')
+    .describe('wrapper', 'Load a external plugin to change the output format of the precompiled templates (for example, "-w custom" will load a module named "nunjucks-custom")')
         .string('wrapper')
         .alias('w', 'wrapper')
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -639,6 +639,7 @@ Precompile a file or directory at **path**. **opts** is a hash with any of the f
 * **env**: the Environment to use (gets extensions and async filters from it)
 * **include**: array of file/folders to include (folders are auto-included, files are auto-excluded)
 * **exclude**: array of file/folders to exclude (folders are auto-included, files are auto-excluded)
+* **wrapper**: call a external plugin to change the output format of the precompiled templates (for example, "custom" will load a module named "nunjucks-custom")
 
 ```js
 var env = new nunjucks.Environment();

--- a/docs/api.md
+++ b/docs/api.md
@@ -639,7 +639,11 @@ Precompile a file or directory at **path**. **opts** is a hash with any of the f
 * **env**: the Environment to use (gets extensions and async filters from it)
 * **include**: array of file/folders to include (folders are auto-included, files are auto-excluded)
 * **exclude**: array of file/folders to exclude (folders are auto-included, files are auto-excluded)
-* **wrapper**: call a external plugin to change the output format of the precompiled templates (for example, "custom" will load a module named "nunjucks-custom")
+* **wrapper**: `function(templates, opts)` Customize the output format of the precompiled templates. This function must return a string 
+    * **templates**: array of objects with the following properties:
+        * **name**: name of the template
+        * **template**: string source of the precompiled template in javascript
+    * **opts**: object of all the above options
 
 ```js
 var env = new nunjucks.Environment();

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -30,7 +30,7 @@ function precompile(input, opts) {
     // * env: the Environment to use (gets extensions and async filters from it)
     // * include: which file/folders to include (folders are auto-included, files are auto-excluded)
     // * exclude: which file/folders to exclude (folders are auto-included, files are auto-excluded)
-    // * wrapper: function(name, template, opts) {...}
+    // * wrapper: function(templates, opts) {...}
     //       Customize the output format to store the compiled template.
     //       By default, templates are stored in a global variable used by the runtime.
     //       A custom loader will be necessary to load your custom wrapper.


### PR DESCRIPTION
As requested on #609, this PR adds docs for the 'wrapper' option of nunjucks' precompile API introduced in #302, and the corresponding option in the CLI in #418.

Please let me know if there's any improvement I can make.