### PR TITLE
Support whitespace control in comment blocks, close #332

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1189,7 +1189,7 @@ var Parser = Object.extend({
 
                 // Same for the succeding block start token
                 if(nextToken &&
-                   ((nextToken.type === lexer.TOKEN_BLOCK_START &&
+                    ((nextToken.type === lexer.TOKEN_BLOCK_START &&
                       nextVal.charAt(nextVal.length - 1) === '-') ||
                     (nextToken.type === lexer.TOKEN_COMMENT &&
                       nextVal.charAt(this.tokens.tags.COMMENT_START.length)
@@ -1220,7 +1220,7 @@ var Parser = Object.extend({
             }
             else if(tok.type === lexer.TOKEN_COMMENT) {
                 this.dropLeadingWhitespace = tok.value.charAt(
-                    tok.value.length - this.tokens.tags.COMMENT_END.length- 1
+                    tok.value.length - this.tokens.tags.COMMENT_END.length - 1
                 ) === '-';
             } else {
                 // Ignore comments, otherwise this should be an error

--- a/src/parser.js
+++ b/src/parser.js
@@ -1189,8 +1189,11 @@ var Parser = Object.extend({
 
                 // Same for the succeding block start token
                 if(nextToken &&
-                   nextToken.type === lexer.TOKEN_BLOCK_START &&
-                   nextVal.charAt(nextVal.length - 1) === '-') {
+                   ((nextToken.type === lexer.TOKEN_BLOCK_START &&
+                      nextVal.charAt(nextVal.length - 1) === '-') ||
+                    (nextToken.type === lexer.TOKEN_COMMENT &&
+                      nextVal.charAt(this.tokens.tags.COMMENT_START.length)
+                        === '-'))) {
                     // TODO: this could be optimized (don't use regex)
                     data = data.replace(/\s*$/, '');
                 }
@@ -1216,7 +1219,9 @@ var Parser = Object.extend({
                 buf.push(new nodes.Output(tok.lineno, tok.colno, [e]));
             }
             else if(tok.type === lexer.TOKEN_COMMENT) {
-              this.dropLeadingWhitespace = false;
+                this.dropLeadingWhitespace = tok.value.charAt(
+                    tok.value.length - this.tokens.tags.COMMENT_END.length- 1
+                ) === '-';
             } else {
                 // Ignore comments, otherwise this should be an error
                 this.fail('Unexpected token at top-level: ' +

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -564,6 +564,30 @@
                      [nodes.Output,
                       [nodes.TemplateData, 'hi']]]]]);
 
+            isAST(parser.parse('hello \n{#- comment #}'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.TemplateData, 'hello']]]);
+
+            isAST(parser.parse('{# comment -#} \n world'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.TemplateData, 'world']]]);
+
+            isAST(parser.parse('hello \n{#- comment -#} \n world'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.TemplateData, 'hello']],
+                   [nodes.Output,
+                    [nodes.TemplateData, 'world']]]);
+
+            isAST(parser.parse('hello \n{# - comment - #} \n world'),
+                  [nodes.Root,
+                   [nodes.Output,
+                    [nodes.TemplateData, 'hello \n']],
+                   [nodes.Output,
+                    [nodes.TemplateData, ' \n world']]]);
+
             // The from statement required a special case so make sure to
             // test it
             isAST(parser.parse('{% from x import y %}\n  hi \n'),


### PR DESCRIPTION
Seems like jingja2 also supports whitespace control in variable blocks. Should nunjucks support that too?

`trimBlocks` and `lstripBlocks` only works in statement blocks(`{% %}`). Maybe They also should be supported in other blocks.  