### PR TITLE
Makes urlize conserve any white space char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 master (unreleased)
 -------------------
 
+* Fix a bug in urlize that would remove line break, tabs and any other
+  "white spacey" char different than white space.
 * Don't suppress errors inside {% if %} tags. Thanks Artemy Tregubenko for
   report and test, Ouyang Yadong for fix. Merge of
   [#634](https://github.com/mozilla/nunjucks/pull/634).

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -822,6 +822,7 @@ linebreaks. Use second behavior if you want to pipe
 * [truncate](http://jinja.pocoo.org/docs/templates/#truncate)
 * [upper](http://jinja.pocoo.org/docs/templates/#upper)
 * [urlencode](http://jinja.pocoo.org/docs/templates/#urlencode)
+* [urlize](http://jinja.pocoo.org/docs/templates/#urlize)
 * [wordcount](http://jinja.pocoo.org/docs/templates/#wordcount)
 * [float](http://jinja.pocoo.org/docs/templates/#float)
 * [int](http://jinja.pocoo.org/docs/templates/#int)

--- a/src/filters.js
+++ b/src/filters.js
@@ -492,7 +492,7 @@ var filters = {
         var wwwRE = /^www\./;
         var tldRE = /\.(?:org|net|com)(?:\:|\/|$)/;
 
-        var words = str.split(/\s+/).filter(function(word) {
+        var words = str.split(/(\s+)/).filter(function(word) {
           // If the word has no length, bail. This can happen for str with
           // trailing whitespace.
           return word && word.length;
@@ -520,7 +520,7 @@ var filters = {
 
         });
 
-        return words.join(' ');
+        return words.join('');
     },
 
     wordcount: function(str) {

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -537,7 +537,7 @@
             equal('{{ "http://jinja.pocoo.org/docs/templates/)" | urlize | safe }}',
                 '<a href="http://jinja.pocoo.org/docs/templates/">http://jinja.pocoo.org/docs/templates/</a>');
             equal('{{ "http://jinja.pocoo.org/docs/templates/\n" | urlize | safe }}',
-                '<a href="http://jinja.pocoo.org/docs/templates/">http://jinja.pocoo.org/docs/templates/</a>');
+                '<a href="http://jinja.pocoo.org/docs/templates/">http://jinja.pocoo.org/docs/templates/</a>\n');
             equal('{{ "http://jinja.pocoo.org/docs/templates/&gt;" | urlize | safe }}',
                 '<a href="http://jinja.pocoo.org/docs/templates/">http://jinja.pocoo.org/docs/templates/</a>');
 
@@ -555,6 +555,10 @@
 
             //markup in the text
             equal('{{ "<b>what up</b>" | urlize | safe }}', '<b>what up</b>');
+
+            //breaklines and tabs in the text
+            equal('{{ "what\nup" | urlize | safe }}', 'what\nup');
+            equal('{{ "what\tup" | urlize | safe }}', 'what\tup');
 
             finish(done);
         });


### PR DESCRIPTION
Addresses issue #596.

The fix was rather simpler, I took the same approach that jinja2 `urlize` [uses](https://github.com/mitsuhiko/jinja2/blob/b78f2617b04cc549ed5fea4eca944c4d8054d187/jinja2/utils.py#L19) and is relying on the feature of `split` with regular expressions: (from [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#Description))

> If separator is a regular expression that contains capturing parentheses, then each time separator is matched, the results (including any undefined results) of the capturing parentheses are spliced into the output array. However, not all browsers support this capability.

Hope this helps!