### PR TITLE
fix range template global to work with zero stop-value

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -40,7 +40,7 @@ function joiner(sep) {
 function globals() {
     return {
         range: function(start, stop, step) {
-            if(!stop && stop !== 0) {
+            if(typeof stop === 'undefined') {
                 stop = start;
                 start = 0;
                 step = 1;

--- a/src/globals.js
+++ b/src/globals.js
@@ -40,7 +40,7 @@ function joiner(sep) {
 function globals() {
     return {
         range: function(start, stop, step) {
-            if(!stop) {
+            if(!stop && stop !== 0) {
                 stop = start;
                 start = 0;
                 step = 1;

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -28,6 +28,7 @@
             equal('{% for i in range(0, 10) %}{{ i }}{% endfor %}', '0123456789');
             equal('{% for i in range(10) %}{{ i }}{% endfor %}', '0123456789');
             equal('{% for i in range(5, 10) %}{{ i }}{% endfor %}', '56789');
+            equal('{% for i in range(-2, 0) %}{{ i }}{% endfor %}', '-2-1');
             equal('{% for i in range(5, 10, 2) %}{{ i }}{% endfor %}', '579');
             equal('{% for i in range(5, 10, 2.5) %}{{ i }}{% endfor %}', '57.5');
             equal('{% for i in range(5, 10, 2.5) %}{{ i }}{% endfor %}', '57.5');


### PR DESCRIPTION
I'm using range to iterate up from a dynamic range, which is negative sometimes. This patch fixes the case that the stop-value is exactly zero. Added test case.

(This will also need a fresh browser build, not included)