### PR TITLE
Support named `endblock` tags, fix #521

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -399,12 +399,15 @@ var Parser = Object.extend({
         this.advanceAfterBlockEnd(tag.value);
 
         node.body = this.parseUntilBlocks('endblock');
+        this.skipSymbol('endblock');
+        this.skipSymbol(node.name.value);
 
-        if(!this.peekToken()) {
+        var tok = this.peekToken();
+        if(!tok) {
             this.fail('parseBlock: expected endblock, got end of file');
         }
 
-        this.advanceAfterBlockEnd();
+        this.advanceAfterBlockEnd(tok.value);
 
         return node;
     },

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -289,6 +289,9 @@
             n = parser.parse('{% block foo %}stuff{% endblock %}');
             expect(n.children[0].typename).to.be('Block');
 
+            n = parser.parse('{% block foo %}stuff{% endblock foo %}');
+            expect(n.children[0].typename).to.be('Block');
+
             n = parser.parse('{% extends "test.html" %}stuff');
             expect(n.children[0].typename).to.be('Extends');
 
@@ -673,6 +676,10 @@
             expect(function() {
                 parser.parse('hello {% block sdf %} data');
             }).to.throwException(/expected endblock/);
+
+            expect(function() {
+                parser.parse('hello {% block sdf %} data{% endblock foo %}');
+            }).to.throwException(/expected block end/);
 
             expect(function() {
                 parser.parse('hello {% bar %} dsfsdf');


### PR DESCRIPTION
As in Jinja2:
http://jinja.pocoo.org/docs/dev/templates/#named-block-end-tags

Also added two tests