### PR TITLE
environemnts dev option is not working

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -31,7 +31,7 @@ var Environment = Obj.extend({
         //  the library)
         // defaults to false
         opts = this.opts = opts || {};
-        this.opts.dev = !!opts.dev;
+        this.dev = !!opts.dev;
 
         // The autoescape flag sets global autoescaping. If true,
         // every string variable will be escaped by default.


### PR DESCRIPTION
environemnt's dev option is not working, because it is being assigned to env.opts.dev but trying to read it from env.dev in line number 436, 468 and 485