### PR TITLE
call configure() when the module initially loads

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,26 +57,17 @@ module.exports.configure = function(templatesPath, opts) {
     return e;
 };
 
+module.exports.configure();
+
 module.exports.compile = function(src, env, path, eagerCompile) {
-    if(!e) {
-        module.exports.configure();
-    }
     return new module.exports.Template(src, env, path, eagerCompile);
 };
 
 module.exports.render = function(name, ctx, cb) {
-    if(!e) {
-        module.exports.configure();
-    }
-
     return e.render(name, ctx, cb);
 };
 
 module.exports.renderString = function(src, ctx, cb) {
-    if(!e) {
-        module.exports.configure();
-    }
-
     return e.renderString(src, ctx, cb);
 };
 


### PR DESCRIPTION
The user will likely call `Nunjucks.render()` (or `renderString`) hundreds of times per second. There's no need to always be checking if we have an environment. We will be needing one anyway, so we might as well create a default environment from the beginning. 

Of course, the user can still override the default one by calling `Nunjucks.configure()` again.