### PR TITLE
Tests may fail on Windows due to line ending issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Checkout example and test fixtures with linux line ending
+# to guarantee test successes
+tests/** text eol=lf


### PR DESCRIPTION
This commit enforce LF line endings on checkout for files in `tests/**` in order to guarantee test success on Windows regardless of the user's git settings.