### PR TITLE
More complex tests for filter blocks (#576) - no solution!

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1196,6 +1196,13 @@
 
             equal('{% filter replace("force", "forth") %}may the force be with you{% endfilter %}',
                   'may the forth be with you');
+
+            equal('{% set foo = "force" %}{% filter replace("force", "forth") %}may the {{ foo }} be with you{% endfilter %}',
+                  'may the forth be with you');
+
+            equal('{% extends "filter-block.html" %}' +
+                  '{% block block1 %}force{% endblock %}',
+                  'may the forth be with you');
             finish(done);
         });
 

--- a/tests/templates/filter-block.html
+++ b/tests/templates/filter-block.html
@@ -1,0 +1,1 @@
+may the {% filter replace("force", "forth") %}{% block block1 %}bar{% endblock %}{% endfilter %} be with you


### PR DESCRIPTION
Adds *failing* tests illustrating both issues mentioned in #576. The additional tests focus on template constructs within the filter block (`{% filter ... %}...{% endfilter %}` as introduced by #254):

1. variable evaluation inside filter block
2. block declaration inside filter block

Both test are added to the list of `it('should handle filter blocks', ...`, which seems to be the project's convention for grouping tests by feature. Nonetheless, the two added test cases fail in different ways:
1. The variable expression test fails due to the discarding of any but the first token. Its output is unexpected.
2. The block declaration test fails due to a reference to undefined. It throws an error.

Both issues are caused by the following line [src/parser.js#L1030-L1032](https://github.com/mozilla/nunjucks/blob/d4b3a07603b5a5c8adacb0c54aca53df8c931c73/src/parser.js#L1030-L1032). It can easily be seen that the given code comment is only true for text-only filter blocks.

---
I also tried some hours to fix the issue, but failed miserably due to my lack of understanding of the available nodes' types. It seemed inappropriate to use `nodes.CallExtension` as done by [SamyPesse/nunjucks-filter](https://github.com/SamyPesse/nunjucks-filter/blob/master/index.js) as this is an extension point and not intended for use within core. Isn't it?