### PR TITLE
Failing test for "if in" with object.

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -127,6 +127,10 @@
                   { food: 'beer' },
                   'beer');
 
+            equal('{% if "pizza" in food %}yum{% endif %}',
+                  { food: {'pizza': true }},
+                  'yum');
+
             finish(done);
         });
 


### PR DESCRIPTION
On the subject of `if`, the documentation says:

> It behaves exactly as javascript's if behaves.

However, in converting some swig templates over, I found that they were failing whenever the template made use of the `in` operator.  Attached is a failing test.