### PR TITLE
Update error messages to include info from error.stack if it's available

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -45,6 +45,18 @@ exports.TemplateError = function(message, lineno, colno) {
         err = message;
         message = message.name + ': ' + message.message;
 
+        // Useful to have the stack info in cases where an error occurs
+        // in a filter or any rendering error.
+        if (err.stack) {
+            // Prevents displaying the same error message line twice that appears
+            // near the stack's beginning (applies to Chrome)
+            if (err.stack.indexOf(message) !== -1) {
+                message = err.stack;
+            } else {
+                message += '\n' + err.stack;
+            }
+        }
+
         try {
             if(err.name = '') {}
         }


### PR DESCRIPTION
We found making this change useful in making it easier to track down things like if an error occurs within our filters. For example, without the change, we were getting:

```
(/mocks/a/great/site/index.html)
  Template render error: (/mocks/a/great/site/index.nunj)
  TypeError: Cannot read property 'length' of undefined
```
vs (with the change)

```
(/mocks/a/great/site/index.html)
Template render error: (/mocks/a/great/site/index.nunj)
  TypeError: Cannot read property 'length' of undefined
  at filters.dictsort (/mocks/node_modules/nunjucks/src/filters.js:75:12)
  at b_main (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:109:59)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:49:25)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:317:1)
  at /mocks/node_modules/nunjucks/src/environment.js:494:25
  at root [as rootRenderFunc] (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:12:1)
  at Obj.extend.render (/mocks/node_modules/nunjucks/src/environment.js:479:15)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:200:6)
  at createTemplate (/mocks/node_modules/nunjucks/src/environment.js:234:25)
  at handle (/mocks/node_modules/nunjucks/src/environment.js:249:25)
  at Object.exports.prettifyError (/mocks/node_modules/nunjucks/src/lib.js:34:15)
  at /mocks/node_modules/nunjucks/src/environment.js:486:31
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:306:12)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:50:12)
  at b_main (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:161:3)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:49:25)
  at eval (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:317:1)
  at /mocks/node_modules/nunjucks/src/environment.js:494:25
  at root [as rootRenderFunc] (eval at <anonymous> (/mocks/node_modules/nunjucks/src/environment.js:565:24), <anonymous>:12:1)
  at Obj.extend.render (/mocks/node_modules/nunjucks/src/environment.js:479:15)
```

Wanted to see if this would be useful to have in master?