### PR TITLE
fixed bad character leading % in {% endraw %}

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -504,7 +504,7 @@ If you want to output any of the special nunjucks tags like `{{`, you can use `r
 ```jinja
 {% raw %}
   this will {{ not be processed }}
-{％ endraw %}
+{% endraw %}
 ```
 
 ### filter


### PR DESCRIPTION
just a bad version of the % in that line of docs, must have been some weird special character version.
For those copy and pasting the example the block would not close.