### PR TITLE
Add test for async error throwing when includes have invalid tags

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -918,6 +918,14 @@
             finish(done);
         });
 
+        it('should throw an error synchronously when including a file with an invalid tag', function() {
+            var callRender = function () {
+                render('{% include "undefined-tag.j2" %}');
+            };
+
+            expect(callRender).to.throwException();
+        });
+
         it('should fail silently on missing templates if requested', function(done) {
             equal('hello world {% include "missing.j2" ignore missing %}',
                   'hello world ');

--- a/tests/templates/undefined-tag.j2
+++ b/tests/templates/undefined-tag.j2
@@ -1,0 +1,1 @@
+{% invalidTag %}


### PR DESCRIPTION
A failing test to demonstrate #678.

If there's a better place to put this test or preferred way to structure it just let me know. I just tried to mimic what's there already.
