### PR TITLE
Add support for boolean globals

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -124,7 +124,7 @@ var Environment = Obj.extend({
     },
 
     getGlobal: function(name) {
-        if(!this.globals[name]) {
+        if(typeof this.globals[name] === 'undefined') {
             throw new Error('global not found: ' + name);
         }
         return this.globals[name];

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -114,6 +114,17 @@
             finish(done);
         });
 
+        it('should allow getting boolean globals', function(done) {
+            var env = new Environment(new Loader(templatesPath));
+            var hello = false;
+
+            env.addGlobal('hello', hello);
+
+            expect(env.getGlobal('hello')).to.be.equal(hello);
+
+            finish(done);
+        });
+
         it('should fail on getting non-existent global', function(done) {
             var env = new Environment(new Loader(templatesPath));
 


### PR DESCRIPTION
When calling the `getGlobal` function it throws an error when the global you want to get is falsey. It should only throw an error when the global is undefined sou you can use real boolean globals in a function (e.g. a filter).