### PR TITLE
Remove string truncation for error output.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -441,7 +441,7 @@ var Compiler = Object.extend({
                 return this._getNodeName(node.target) + '["' +
                        this._getNodeName(node.val) + '"]';
             case 'Literal':
-                return node.value.toString().substr(0, 10);
+                return node.value.toString();
             default:
                 return '--expression--';
         }

--- a/tests/runtime.js
+++ b/tests/runtime.js
@@ -40,6 +40,14 @@
             finish(done);
         });
 
+        it('should report full function name in error', function(done) {
+            render('{{ foo.barThatIsLongerThanTen() }}', {}, { noThrow: true }, function(err) {
+                expect(err).to.match(/foo\["barThatIsLongerThanTen"\]/);
+            });
+
+            finish(done);
+        });
+
         it('should report the failed function calls w/multiple args', function(done) {
             render('{{ foo.bar("multiple", "args") }}', {}, { noThrow: true }, function(err) {
                 expect(err).to.match(/foo\["bar"\]/);


### PR DESCRIPTION
I'd like to be able to see the full name of a missing function when an error is thrown.  In this PR, I removed the string truncation that is occurring for error outputs.