### PR TITLE
Support ECMAScript 2015 Map and Set in length filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -175,7 +175,17 @@ var filters = {
     length: function(val) {
         var value = normalize(val, '');
 
-        return value !== undefined ? value.length : 0;
+        if(value !== undefined) {
+            if(
+                (typeof Map === 'function' && value instanceof Map) ||
+                (typeof Set === 'function' && value instanceof Set)
+            ) {
+                // ECMAScript 2015 Maps and Sets
+                return value.size;
+            }
+            return value.length;
+        }
+        return 0;
     },
 
     list: function(val) {

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -264,6 +264,16 @@
             equal('{{ undefined | length }}', '0');
             equal('{{ null | length }}', '0');
             equal('{{ nothing | length }}', '0');
+            if(typeof Map === 'function') {
+                var map = new Map([['key1', 'value1'], ['key2', 'value2']]);
+                map.set('key3', 'value3');
+                equal('{{ map | length }}', {map: map}, '3');
+            }
+            if(typeof Set === 'function') {
+                var set = new Set(['value1']);
+                set.add('value2');
+                equal('{{ set | length }}', {set: set}, '2');
+            }
             finish(done);
         });
 


### PR DESCRIPTION
They both expose a 'size' property:
http://www.ecma-international.org/ecma-262/6.0/#sec-get-map.prototype.size
http://www.ecma-international.org/ecma-262/6.0/#sec-get-set.prototype.size

Use that instead of the 'length' property.
Also added two tests that only run if the respective globals are set.