### PR TITLE
fix link to installJinjaCompat

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ features, it should be easy to make templates compatible.
 
 Nunjucks has experimental support for installing APIs into the
 templating environment to help with Jinja compatibility. See
-[installJinjaCompat](/api.html#installjinjacompat).
+[installJinjaCompat](api.html#installjinjacompat).
 
 Additionally, there are few jinja2 features not implemented in nunjucks:
 


### PR DESCRIPTION
Target was `/api.html#installjinjacompat` resolving to `https://mozilla.github.io/api.html#installjinjacompat` instead of `https://mozilla.github.io/nunjucks/api.html#installjinjacompat`. 

This fix changes the target to a relative path, resolving to the correct `nunjucks/api.html` page.