### PR TITLE
Give Nunjucks the ability to match properly output of Jinja's 'round' filter

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -909,7 +909,7 @@ template. Useful for debugging: `{{ foo | dump }}`.
 * [rejectattr](http://jinja.pocoo.org/docs/templates/#rejectattr) (only the single-argument form)
 * [replace](http://jinja.pocoo.org/docs/templates/#replace) (the first argument can take a JS regular expression)
 * [reverse](http://jinja.pocoo.org/docs/templates/#reverse)
-* [round](http://jinja.pocoo.org/docs/templates/#round)
+* [round](http://jinja.pocoo.org/docs/templates/#round) (additional argument `jinjaCompat` adds ability to match jinja's default floating point of one decimal place if set to true)
 * [safe](http://jinja.pocoo.org/docs/templates/#safe)
 * [selectattr](http://jinja.pocoo.org/docs/templates/#selectattr) (only the single-argument form)
 * [slice](http://jinja.pocoo.org/docs/templates/#slice)

--- a/src/filters.js
+++ b/src/filters.js
@@ -317,8 +317,10 @@ var filters = {
         return arr;
     },
 
-    round: function(val, precision, method) {
+    round: function(val, precision, method, jinjaCompat) {
         precision = precision || 0;
+        jinjaCompat = jinjaCompat || false;
+
         var factor = Math.pow(10, precision);
         var rounder;
 
@@ -332,7 +334,14 @@ var filters = {
             rounder = Math.round;
         }
 
-        return rounder(val * factor) / factor;
+        var roundedValue = rounder(val * factor) / factor;
+
+        if(Number.isInteger(roundedValue) && jinjaCompat) {
+            var floatingPointNumber = roundedValue.toFixed(1);
+            roundedValue = floatingPointNumber;
+        }
+
+        return roundedValue;
     },
 
     slice: function(arr, slices, fillWith) {

--- a/src/filters.js
+++ b/src/filters.js
@@ -10,6 +10,10 @@ function normalize(value, defaultValue) {
     return value;
 }
 
+function isInt(n) {
+    return n % 1 === 0;
+}
+
 var filters = {
     abs: function(n) {
         return Math.abs(n);
@@ -336,7 +340,7 @@ var filters = {
 
         var roundedValue = rounder(val * factor) / factor;
 
-        if(Number.isInteger(roundedValue) && jinjaCompat) {
+        if(isInt(roundedValue) && jinjaCompat) {
             var floatingPointNumber = roundedValue.toFixed(1);
             roundedValue = floatingPointNumber;
         }

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -368,7 +368,9 @@
 
         it('round', function(done) {
             equal('{{ 4.5 | round }}', '5');
+            equal('{{ 4.5 | round(0, "normal", true) }}', '5.0');
             equal('{{ 4.5 | round(0, "floor") }}', '4');
+            equal('{{ 4.5 | round(0, "floor", true) }}', '4.0');
             equal('{{ 4.12345 | round(4) }}', '4.1235');
             equal('{{ 4.12344 | round(4) }}', ('4.1234'));
             finish(done);


### PR DESCRIPTION
* Added option 'jinjaCompat' param to 'round' filter to match jinja's default returned floating point
  i.e. `{{ 3.4545 | round(0, 'common', true) }}` will return `4.0` instead of `4`
* Added tests
* Updated docs to reflect changes