### PR TITLE
fix missing nunjucks. prefix in API docs > Environment

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -183,16 +183,16 @@ the browser. See [`Loader`](#loader) for more information.
 
 ```js
 // the FileSystemLoader is available if in node
-var env = new Environment(new nunjucks.FileSystemLoader('views'));
+var env = new nunjucks.Environment(new nunjucks.FileSystemLoader('views'));
 
-var env = new Environment(new nunjucks.FileSystemLoader('views'),
+var env = new nunjucks.Environment(new nunjucks.FileSystemLoader('views'),
                           { autoescape: false });
 
-var env = new Environment([new nunjucks.FileSystemLoader('views'),
+var env = new nunjucks.Environment([new nunjucks.FileSystemLoader('views'),
                            new MyCustomLoader()]);
 
 // the WebLoader is available if in the browser
-var env = new Environment(new nunjucks.WebLoader('/views'));
+var env = new nunjucks.Environment(new nunjucks.WebLoader('/views'));
 ```
 {% endapi %}
 


### PR DESCRIPTION
Change `new Environment` into `new nunjucks.Environment` as `Environment` is only available namespaced under `nunjucks`.
By fixing this:
* the example code snippet can be copy-pasted without throwing an error.
* the syntax is consistent with [API docs > Loader](https://github.com/mozilla/nunjucks/blob/master/docs/api.md#loader) and [API docs > Filters](https://github.com/mozilla/nunjucks/blob/master/docs/api.md#custom-filters) etc.