### PR TITLE
Travis CI and AppVeyor: add Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
   - "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
+    - nodejs_version: "6"
     - nodejs_version: "5"
     - nodejs_version: "4"
     - nodejs_version: "1"


### PR DESCRIPTION
The new Node.js v6 branch will become the new Active Long Term Support stream in October of 2016, and will continue to be supported actively until April of 2018.

https://nodejs.org/en/blog/release/v6.0.0/