### PR TITLE
wrap all four browser bundles with UMD using libraryTarget webkit option

### DIFF
--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -35,7 +35,8 @@ var config = {
     output: {
         path: path.join(__dirname, '../browser'),
         filename: TARGET,
-        library: 'nunjucks'
+        library: 'nunjucks',
+        libraryTarget: 'umd'
     },
     node: {
         process: 'empty'


### PR DESCRIPTION
The bundles are not updated in this PR to keep it clean, but the diff for the nunjucks-slim is pictured below. (Happy to update the PR to include compiled bundle changes if it would be helpful.)

![image](https://cloud.githubusercontent.com/assets/1483694/15165717/eb92e6ca-16cc-11e6-82da-3938a8e69f90.png)
