### PR TITLE
Force unix style path separators in precompile

### DIFF
--- a/src/precompile.js
+++ b/src/precompile.js
@@ -88,6 +88,8 @@ function precompile(input, opts) {
         for(var i=0; i<templates.length; i++) {
             var name = templates[i].replace(path.join(input, '/'), '');
 
+            name = name.replace('\\', '/');
+
             try {
                 precompiled.push( _precompile(
                     fs.readFileSync(templates[i], 'utf-8'),

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -88,7 +88,7 @@ function precompile(input, opts) {
         for(var i=0; i<templates.length; i++) {
             var name = templates[i].replace(path.join(input, '/'), '');
 
-            name = name.replace('\\', '/');
+            name = name.replace(/\\/g, '/');
 
             try {
                 precompiled.push( _precompile(

--- a/tests/precompile.js
+++ b/tests/precompile.js
@@ -18,5 +18,19 @@
         it('should return a string', function() {
             expect(precompileString('{{ test }}', { name: 'test.j2' })).to.be.an('string');
         });
+
+        describe('templates', function() {
+            it('should return *NIX path seperators', function() {
+                var fileName;
+
+                precompile('./tests/templates/item.j2', {
+                    wrapper: function(templates) {
+                        fileName = templates[0].name;
+                    }
+                });
+
+                expect(fileName).to.not.contain('\\');
+            });
+        });
     });
 })();


### PR DESCRIPTION
If you precompile in Windows, Nunjucks uses Windows path separators. This leads to inconsistent results, when precompiling between *NIX and Windows.

PR standardises path separators to *NIX style. All tests passing.