### PR TITLE
Should allow blocks in custom tag.

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var lib = require('./lib');
+var util = require('util');
 // jshint -W079
 var Object = require('./object');
 
@@ -11,6 +12,12 @@ function traverseAndCheck(obj, type, results) {
 
     if(obj instanceof Node) {
         obj.findAll(type, results);
+    }
+
+    if(util.isArray(obj)) {
+        lib.each(obj, function(arg, i) {
+            traverseAndCheck(obj[i], type, results);
+        });
     }
 }
 

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1350,6 +1350,36 @@
             finish(done);
         });
 
+        it('should allow blocks in custom tag', function(done) {
+            function testExtension() {
+                // jshint validthis: true
+                this.tags = ['test'];
+
+                this.parse = function(parser, nodes) {
+                    parser.advanceAfterBlockEnd();
+
+                    var content = parser.parseUntilBlocks('endtest');
+                    var tag = new nodes.CallExtension(this, 'run', null, [content]);
+                    parser.advanceAfterBlockEnd();
+
+                    return tag;
+                };
+
+                this.run = function(context, content) {
+                    // Reverse the string
+                    return content();
+                };
+            }
+
+            var opts = { extensions: { 'testExtension': new testExtension() }};
+            render('{% extends "block-inside-custom-tag.njk" %}' +
+                '{% block hello%}{{ super() }}, world!{% endblock %}', null, opts, function(err, res) {
+                expect(res).to.be('hello, world!\n');
+            });
+
+            finish(done);
+        });
+
         it('should autoescape by default', function(done) {
             equal('{{ foo }}', { foo: '"\'<>&'}, '&quot;&#39;&lt;&gt;&amp;');
             finish(done);

--- a/tests/templates/block-inside-custom-tag.njk
+++ b/tests/templates/block-inside-custom-tag.njk
@@ -1,0 +1,1 @@
+{% test %}{% block hello %}hello{% endblock %}{% endtest %}


### PR DESCRIPTION
For example:

#### Usage:
```
{# block-inside-custom-tag.njk #}
{% test %}
  {% block hello %}hello{% endblock %}
{% endtest %}
```
```
{% extends "block-inside-custom-tag.njk" %}
{% block hello%}{{ super() }}, world!{% endblock %}
```