### PR TITLE
Bump chokidar version to fix node 6.x deprecated call

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "James Long <longster@gmail.com>",
   "dependencies": {
     "asap": "^2.0.3",
-    "chokidar": "^1.0.0",
+    "chokidar": "^1.6.0",
     "yargs": "^3.32.0"
   },
   "browser": "./browser/nunjucks.js",


### PR DESCRIPTION
Root cause comes from `fsevents`, [see PR](https://github.com/strongloop/fsevents/pull/128)

Before the bump
```
$ node --version
v6.3.0

$ node -e 'require("chokidar")'
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.

==== JS stack trace =========================================

[... omitted]
=====================


==== C stack trace ===============================

 1: v8::Template::Set(v8::Local<v8::Name>, v8::Local<v8::Data>, v8::PropertyAttribute)
 2: fse::FSEvents::Initialize(v8::Local<v8::Object>)
 3: node::DLOpen(v8::FunctionCallbackInfo<v8::Value> const&)
 4: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&))
 5: v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::(anonymous namespace)::BuiltinArguments<(v8::internal::BuiltinExtraArguments)1>)
 6: v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*)
 7: 0x17987870961b
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.

==== JS stack trace =========================================
[... omitted]
```

After, everything works fine, no more stacktrace, including for downstream projects