### PR TITLE
Add support for finding object length (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Changelog
 2.x (unreleased)
 ----------------
 
+* Add support for finding an object's "length" in length filter.
+
 * Ensure that precompiling on Windows still outputs POSIX-style path
   separators. Merge of [#761](https://github.com/mozilla/nunjucks/pull/761).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog
 ----------------
 
 * Add support for finding an object's "length" in length filter.
+  Merge of [#813](https://github.com/mozilla/nunjucks/pull/813).
 
 * Ensure that precompiling on Windows still outputs POSIX-style path
   separators. Merge of [#761](https://github.com/mozilla/nunjucks/pull/761).

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1209,18 +1209,22 @@ Get the last item in an array:
 
 ### length
 
-Return the length of an array:
+Return the length of an array or string, or the number of keys in an object:
 
 **Input**
 
 ```jinja
 {{ [1,2,3] | length }}
+{{ "test" | length }}
+{{ {key: value} | length }}
 ```
 
 **Output**
 
 ```jinja
 3
+4
+1
 ```
 
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -183,6 +183,10 @@ var filters = {
                 // ECMAScript 2015 Maps and Sets
                 return value.size;
             }
+            if(lib.isObject(value) && !(value instanceof r.SafeString)) {
+                // Objects (besides SafeStrings), non-primative Arrays
+                return Object.keys(value).length;
+            }
             return value.length;
         }
         return 0;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -261,9 +261,21 @@
             equal('{{ [1,2,3] | length }}', '3');
             equal('{{ blah|length }}', '0');
             equal('{{ str | length }}', {str:r.markSafe('blah')}, '4');
+            equal('{{ str | length }}', {str:'blah'}, '4');
+            equal('{{ str | length }}', {str:new String('blah')}, '4'); //jshint ignore:line
             equal('{{ undefined | length }}', '0');
             equal('{{ null | length }}', '0');
             equal('{{ nothing | length }}', '0');
+            equal('{{ obj | length }}', {obj: {}}, '0');
+            equal('{{ obj | length }}', {obj: {key: 'value'}}, '1');
+            equal('{{ obj | length }}', {obj: {key: 'value', length: 5}}, '2');
+            equal('{{ obj.length }}', {obj: {key: 'value', length: 5}}, '5');
+            equal('{{ arr | length }}', {arr: [0, 1]}, '2');
+            equal('{{ arr | length }}', {arr: [0, , 2]}, '3'); // jshint ignore:line
+            equal('{{ arr | length }}', {arr: new Array(0, 1)}, '2');
+            var arr = new Array(0, 1);
+            arr.key = 'value';
+            equal('{{ arr | length }}', {arr: arr}, '2');
             if(typeof Map === 'function') {
                 var map = new Map([['key1', 'value1'], ['key2', 'value2']]);
                 map.set('key3', 'value3');


### PR DESCRIPTION
In length builtin filter. For objects, "length" is the number of keys
the object has.

Fixes #283