### PR TITLE
Broadened Windows precompile support to include strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Changelog
 * Allow full expressions (incl. filters) in import and from tags. Thanks legutierr.
   Merge of [#710](https://github.com/mozilla/nunjucks/pull/710).
 
+* OS agnostic file paths in precompile. Merge of [#825](https://github.com/mozilla/nunjucks/pull/825).
 
 2.4.2 (Apr 15 2016)
 -------------------

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -88,8 +88,6 @@ function precompile(input, opts) {
         for(var i=0; i<templates.length; i++) {
             var name = templates[i].replace(path.join(input, '/'), '');
 
-            name = name.replace(/\\/g, '/');
-
             try {
                 precompiled.push( _precompile(
                     fs.readFileSync(templates[i], 'utf-8'),
@@ -118,6 +116,8 @@ function _precompile(str, name, env) {
     var asyncFilters = env.asyncFilters;
     var extensions = env.extensionsList;
     var template;
+
+    name = name.replace(/\\/g, '/');
 
     try {
         template = compiler.compile(str,

--- a/tests/precompile.js
+++ b/tests/precompile.js
@@ -31,6 +31,20 @@
 
                 expect(fileName).to.not.contain('\\');
             });
+
+            it('should return *NIX path seperators, when name is passed as option', function() {
+                var fileName;
+
+                precompile('<span>test</span>', {
+                    name: 'path\\to\\file.j2',
+                    isString: true,
+                    wrapper: function(templates) {
+                        fileName = templates[0].name;
+                    }
+                });
+
+                expect(fileName).to.not.contain('\\');
+            });
         });
     });
 })();

--- a/tests/precompile.js
+++ b/tests/precompile.js
@@ -29,7 +29,7 @@
                     }
                 });
 
-                expect(fileName).to.not.contain('\\');
+                expect(fileName).to.equal('./tests/templates/item.njk');
             });
 
             it('should return *NIX path seperators, when name is passed as option', function() {
@@ -43,7 +43,7 @@
                     }
                 });
 
-                expect(fileName).to.not.contain('\\');
+                expect(fileName).to.equal('path/to/file.j2');
             });
         });
     });


### PR DESCRIPTION
I initially created #761 to deal with incorrectly formatted paths, when precompiling in Windows. The original pull request only dealt with directories, this change also deals with strings.