### PR TITLE
Mention that else is optional in inline if expressions

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -755,6 +755,12 @@ is especially useful for default values like so:
 {{ baz(foo if foo else "default") }}
 ```
 
+Unlike javascript's ternary operator, the `else` is optional:
+
+```jinja
+{{ "true" if foo }}
+```
+
 ### Function Calls
 
 If you have passed a javascript method to your template, you can call it like


### PR DESCRIPTION
This is wasn't immediately obvious to me, especially with the comparison to javascript's ternary operator.