### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+Proposed change:
+
+{{
+	Please replace this with a human-friendly description of your proposed change.
+	* If you have multiple changes, try to split them into separate PRs.
+	* If this change closes an issue, please write "Closes #{number}".
+}}
+
+Closes # .
+
+
+## Checklist
+
+I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.
+
+* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
+* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
+* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
+* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).
+
+(Tick of items by replacing `[ ]` by `[x]`)


### PR DESCRIPTION
## Summary

Proposed change:

This change sets a [default Pull Request template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) for this repository as suggested in an [issue comment](https://github.com/mozilla/nunjucks/issues/821#issuecomment-245088655). The aim of this template is to ensure PRs are relevant and easy to review & release. This PR itself is written in the template as well to show how it works.

Requires #851 to be merged first as it links to the new "purpose" section.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).