### PR TITLE
Fix/order builtin filters alphabetically

### DIFF
--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -856,42 +856,6 @@ Nunjucks a porté la plupart des filtres de jinja, et il a ses propres filtres. 
 de travailler sur notre documentation pour les filtres. Certains d'entre eux sont documentés
 ci-dessous, pour le reste, vous pouvez cliquer sur le site de jinja.
 
-### default(value, default, [boolean])
-
-(raccourci avec `d`)
-
-Si `value` est strictement `undefined`, cela retourne `default`, sinon `value`. Si
-`boolean` est true, toute valeur JavaScript fausse retournera `default` (false, "",
-etc)
-
-**La version 2.0 a changé le comportement par défaut de ce filtre.
-  Auparavant, il agissait comme si `boolean` était à true par défaut et donc toute
-  valeur fausse retournait `default`. Dans la 2.0, le comportement par défaut retourne
-  `default` seulement pour une valeur `undefined`. Vous pouvez obtenir l'ancien
-  comportement en passant `true` à `boolean`, ou en utilisant simplement `value or default`.**
-
-### sort(arr, reverse, caseSens, attr)
-
-Tri `arr` avec la fonction `arr.sort` de JavaScript. Si `reverse` est à true, le résultat
-sera inversé. Le tri est insensible à la casse par défaut, mais en paramétrant `caseSens`
-à true, cela le rend sensible à la casse. Si `attr` est passé, cela permettra de comparer `attr` à
-chaque élément.
-
-### striptags (value, [preserve_linebreaks])
-
-C'est similaire à
-[striptags](http://jinja.pocoo.org/docs/templates/#striptags) de jinja. Si
-`preserve_linebreaks` est à false (par défaut), cela enlève les balises SGML/XML et remplace
-les espaces adjacents par un seul espace. Si `preserve_linebreaks` est à true,
-cela normalise les espaces, en essayant de préserver les sauts de lignes originaux. Utiliser le second
-comportement si vous voulez utiliser ceci `{{ text | striptags | nl2br }}`. Sinon
-utilisez le comportement par défaut.
-
-### dump (object)
-
-Appelle `JSON.stringify` sur un objet et déverse le résultat dans le
-template. C'est utile pour le débogage : `{{ foo | dump }}`.
-
 ### abs
 
 Retourne la valeur absolue de l'argument :
@@ -962,6 +926,20 @@ Centre la valeur dans un champ d'une largeur donnée :
 fooo
 ```
 
+### default(value, default, [boolean])
+
+(raccourci avec `d`)
+
+Si `value` est strictement `undefined`, cela retourne `default`, sinon `value`. Si
+`boolean` est true, toute valeur JavaScript fausse retournera `default` (false, "",
+etc)
+
+**La version 2.0 a changé le comportement par défaut de ce filtre.
+  Auparavant, il agissait comme si `boolean` était à true par défaut et donc toute
+  valeur fausse retournait `default`. Dans la 2.0, le comportement par défaut retourne
+  `default` seulement pour une valeur `undefined`. Vous pouvez obtenir l'ancien
+  comportement en passant `true` à `boolean`, ou en utilisant simplement `value or default`.**
+  
 ### dictsort
 
 Tri un dictionnaire et rend des paires (clé, valeur) :
@@ -985,6 +963,11 @@ Tri un dictionnaire et rend des paires (clé, valeur) :
 ```jinja
 a b c d e f
 ```
+
+### dump (object)
+
+Appelle `JSON.stringify` sur un objet et déverse le résultat dans le
+template. C'est utile pour le débogage : `{{ foo | dump }}`.
 
 ### escape (aliased as e)
 
@@ -1523,6 +1506,13 @@ Découpe un itérateur et retourne une liste de listes contenant ces éléments 
 </div>
 ```
 
+### sort(arr, reverse, caseSens, attr)
+
+Tri `arr` avec la fonction `arr.sort` de JavaScript. Si `reverse` est à true, le résultat
+sera inversé. Le tri est insensible à la casse par défaut, mais en paramétrant `caseSens`
+à true, cela le rend sensible à la casse. Si `attr` est passé, cela permettra de comparer `attr` à
+chaque élément.
+
 ### string
 
 Convertit un objet en une chaine :
@@ -1539,8 +1529,8 @@ Convertit un objet en une chaine :
 **Sortie**
 
 ```jinja
-1,2,3,4,
-```
+1,2,3,4,```
+
 
 ### sum
 
@@ -1558,6 +1548,16 @@ Rend la somme des éléments dans le tableau :
 ```jinja
 6
 ```
+
+### striptags (value, [preserve_linebreaks])
+
+C'est similaire à
+[striptags](http://jinja.pocoo.org/docs/templates/#striptags) de jinja. Si
+`preserve_linebreaks` est à false (par défaut), cela enlève les balises SGML/XML et remplace
+les espaces adjacents par un seul espace. Si `preserve_linebreaks` est à true,
+cela normalise les espaces, en essayant de préserver les sauts de lignes originaux. Utiliser le second
+comportement si vous voulez utiliser ceci `{{ text | striptags | nl2br }}`. Sinon
+utilisez le comportement par défaut.
 
 ### title
 

--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -987,22 +987,6 @@ Les résultats rendent la valeur comme une chaîne de balisage.
 &lt;html&gt;
 ```
 
-### float
-
-Convertit une valeur en un nombre à virgule flottant. Si la conversion échoue, 0.0 est retourné.
-Cette valeur par défaut peut être modifiée en utilisant le premier paramètre.
-
-**Entrée**
-
-```jinja
-{{ "3.5" | float }}
-```
-
-**Sortie**
-
-```jinja
-3.5
-```
 
 ### first
 
@@ -1019,6 +1003,23 @@ Donne le premier élément dans un tableau :
 
 ```jinja
 1
+```
+
+### float
+
+Convertit une valeur en un nombre à virgule flottant. Si la conversion échoue, 0.0 est retourné.
+Cette valeur par défaut peut être modifiée en utilisant le premier paramètre.
+
+**Entrée**
+
+```jinja
+{{ "3.5" | float }}
+```
+
+**Sortie**
+
+```jinja
+3.5
 ```
 
 ### groupby

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -894,11 +894,6 @@ normalizes whitespace, trying to preserve original linebreaks. Use second
 behavior if you want to pipe `{{ text | striptags | nl2br }}`. Use default one
 otherwise.
 
-### dump (object)
-
-Call `JSON.stringify` on an object and dump the result into the
-template. Useful for debugging: `{{ foo | dump }}`.
-
 ### abs
 
 Return the absolute value of the argument:
@@ -992,6 +987,10 @@ Sort a dict and yield (key, value) pairs:
 ```jinja
 a b c d e f
 ```
+### dump (object)
+
+Call `JSON.stringify` on an object and dump the result into the
+template. Useful for debugging: `{{ foo | dump }}`.
 
 ### escape (aliased as e)
 
@@ -1011,23 +1010,6 @@ Marks return value as markup string
 &lt;html&gt;
 ```
 
-### float
-
-Convert a value into a floating point number. If the conversion fails 0.0 is returned.
-This default can be overridden by using the first parameter.
-
-**Input**
-
-```jinja
-{{ "3.5" | float }}
-```
-
-**Output**
-
-```jinja
-3.5
-```
-
 ### first
 
 Get the first item in an array:
@@ -1043,6 +1025,23 @@ Get the first item in an array:
 
 ```jinja
 1
+```
+
+### float
+
+Convert a value into a floating point number. If the conversion fails 0.0 is returned.
+This default can be overridden by using the first parameter.
+
+**Input**
+
+```jinja
+{{ "3.5" | float }}
+```
+
+**Output**
+
+```jinja
+3.5
 ```
 
 ### groupby

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -863,39 +863,7 @@ Nunjucks has ported most of jinja's filters, and has a few of its own.  We need
 to work on our own documentation for filters. Some of them are documented
 below, for the rest you can click through to jinja's site.
 
-### default(value, default, [boolean])
-
-(aliased as `d`)
-
-If `value` is strictly `undefined`, return `default`, otherwise `value`. If
-`boolean` is true, any JavaScript falsy value will return `default` (false, "",
-etc)
-
-**In version 2.0, this filter changed the default behavior of this
-  filter. Previously, it acted as if `boolean` was true by default, and any
-  falsy value would return `default`. In 2.0 the default is only an `undefined`
-  value returns `default`. You can get the old behavior by passing `true` to
-  `boolean`, or just use `value or default`.**
-
-### sort(arr, reverse, caseSens, attr)
-
-Sort `arr` with JavaScript's `arr.sort` function. If `reverse` is true, result
-will be reversed. Sort is case-insensitive by default, but setting `caseSens`
-to true makes it case-sensitive. If `attr` is passed, will compare `attr` from
-each item.
-
-### striptags (value, [preserve_linebreaks])
-
-Analog of jinja's
-[striptags](http://jinja.pocoo.org/docs/templates/#striptags). If
-`preserve_linebreaks` is false (default), strips SGML/XML tags and replaces
-adjacent whitespace with one space.  If `preserve_linebreaks` is true,
-normalizes whitespace, trying to preserve original linebreaks. Use second
-behavior if you want to pipe `{{ text | striptags | nl2br }}`. Use default one
-otherwise.
-
 ### abs
-
 Return the absolute value of the argument:
 
 **Input**
@@ -963,6 +931,20 @@ Center the value in a field of a given width:
 ```jinja
 fooo
 ```
+
+### default(value, default, [boolean])
+
+(aliased as `d`)
+
+If `value` is strictly `undefined`, return `default`, otherwise `value`. If
+`boolean` is true, any JavaScript falsy value will return `default` (false, "",
+etc)
+
+**In version 2.0, this filter changed the default behavior of this
+  filter. Previously, it acted as if `boolean` was true by default, and any
+  falsy value would return `default`. In 2.0 the default is only an `undefined`
+  value returns `default`. You can get the old behavior by passing `true` to
+  `boolean`, or just use `value or default`.**
 
 ### dictsort
 
@@ -1528,6 +1510,12 @@ Slice an iterator and return a list of lists containing those items:
     </ul>
 </div>
 ```
+### sort(arr, reverse, caseSens, attr)
+
+Sort `arr` with JavaScript's `arr.sort` function. If `reverse` is true, result
+will be reversed. Sort is case-insensitive by default, but setting `caseSens`
+to true makes it case-sensitive. If `attr` is passed, will compare `attr` from
+each item.
 
 ### string
 
@@ -1547,6 +1535,16 @@ Convert an object to a string:
 ```jinja
 1,2,3,4,
 ```
+
+### striptags (value, [preserve_linebreaks])
+
+Analog of jinja's
+[striptags](http://jinja.pocoo.org/docs/templates/#striptags). If
+`preserve_linebreaks` is false (default), strips SGML/XML tags and replaces
+adjacent whitespace with one space.  If `preserve_linebreaks` is true,
+normalizes whitespace, trying to preserve original linebreaks. Use second
+behavior if you want to pipe `{{ text | striptags | nl2br }}`. Use default one
+otherwise.
 
 ### sum
 


### PR DESCRIPTION
- added correct order built-in filters for English
- added correct order built-in filters for French

- havent added correct order for filters in Chinese because the links are referencing to Jinja's site. which should be fixed. By adding the same content as in french and english.

-also it seems that in Chinese when you scroll down the page to builtin filters the layout of the page breaks I will post a new issue for this (done: #866).

closes #858
