### PR TITLE
fix duplication error in the expressions sections

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -671,8 +671,8 @@ minus sign (`-`) to the start or end block tag.
 {%- endfor %}
 ```
 
-The exact output of the above would be "12345". The `-%}` strips the whitespace
-right after the tag, and the `{%-` strips the whitespace right before the tag.
+The exact output of the above would be "12345". The `{%-` strips the whitespace
+right before the tag, and `-%}` the strips the whitespace right after the tag.
 
 ## Expressions
 


### PR DESCRIPTION
- fix for duplication of documentation at the examples section of the expressions documentation.

- apparently the tags weren't escaped properly 

closes #869 