### PR TITLE
add `verbatim` as alias of `raw` for parity w/ Twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Changelog
 * Fix handling of macro arg with default value which shares a name with another
   macro. Merge of [#791](https://github.com/mozilla/nunjucks/pull/791).
 
+* Add `verbatim` as an alias of `raw` for compatibility with Twig.
+  Merge of [#874](https://github.com/mozilla/nunjucks/pull/874).
+
 
 2.5.2 (Sep 14 2016)
 ----------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -554,6 +554,11 @@ object: `{% import name + ".html" as obj %}`.
 If you want to output any of the special Nunjucks tags like `{{`, you can use
 a `{% raw %}` block and anything inside of it will be output as plain text.
 
+### verbatim
+
+`{% verbatim %}` has identical behavior as [`{% raw %}`](#raw). It is added for
+compatibility with the [Twig `verbatim` tag](http://twig.sensiolabs.org/doc/tags/verbatim.html).
+
 ### filter
 
 A `filter` block allows you to call a filter with the contents of the

--- a/src/parser.js
+++ b/src/parser.js
@@ -580,7 +580,6 @@ var Parser = Object.extend({
         tagName = tagName || 'raw';
         var endTagName = 'end' + tagName;
         // Look for upcoming raw blocks (ignore all other kinds of blocks)
-        //var rawBlockRegex = /([\s\S]*?){%\s*(raw|endraw)\s*(?=%})%}/;
         var rawBlockRegex = new RegExp('([\\s\\S]*?){%\\s*(' + tagName + '|' + endTagName + ')\\s*(?=%})%}');
         var rawLevel = 1;
         var str = '';

--- a/src/parser.js
+++ b/src/parser.js
@@ -544,6 +544,7 @@ var Parser = Object.extend({
 
         switch(tok.value) {
         case 'raw': return this.parseRaw();
+        case 'verbatim': return this.parseRaw('verbatim');
         case 'if':
         case 'ifAsync':
             return this.parseIf();
@@ -575,9 +576,12 @@ var Parser = Object.extend({
         return node;
     },
 
-    parseRaw: function() {
+    parseRaw: function(tagName) {
+        tagName = tagName || 'raw';
+        var endTagName = 'end' + tagName;
         // Look for upcoming raw blocks (ignore all other kinds of blocks)
-        var rawBlockRegex = /([\s\S]*?){%\s*(raw|endraw)\s*(?=%})%}/;
+        //var rawBlockRegex = /([\s\S]*?){%\s*(raw|endraw)\s*(?=%})%}/;
+        var rawBlockRegex = new RegExp('([\\s\\S]*?){%\\s*(' + tagName + '|' + endTagName + ')\\s*(?=%})%}');
         var rawLevel = 1;
         var str = '';
         var matches = null;
@@ -594,9 +598,9 @@ var Parser = Object.extend({
             var blockName = matches[2];
 
             // Adjust rawlevel
-            if(blockName === 'raw') {
+            if(blockName === tagName) {
                 rawLevel += 1;
-            } else if(blockName === 'endraw') {
+            } else if(blockName === endTagName) {
                 rawLevel -= 1;
             }
 

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -499,6 +499,69 @@
                    [nodes.Output, [nodes.TemplateData, '\n']]]);
         });
 
+        it('should parse verbatim', function() {
+            isAST(parser.parse('{% verbatim %}hello {{ {% %} }}{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, 'hello {{ {% %} }}']]]);
+        });
+
+        it('should parse verbatim with broken variables', function() {
+            isAST(parser.parse('{% verbatim %}{{ x }{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, '{{ x }']]]);
+        });
+
+        it('should parse verbatim with broken blocks', function() {
+            isAST(parser.parse('{% verbatim %}{% if i_am_stupid }Still do your job well{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, '{% if i_am_stupid }Still do your job well']]]);
+        });
+
+        it('should parse verbatim with pure text', function() {
+            isAST(parser.parse('{% verbatim %}abc{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, 'abc']]]);
+        });
+
+
+        it('should parse verbatim with verbatim blocks', function() {
+            isAST(parser.parse('{% verbatim %}{% verbatim %}{{ x }{% endverbatim %}{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, '{% verbatim %}{{ x }{% endverbatim %}']]]);
+        });
+
+        it('should parse verbatim with comment blocks', function() {
+            isAST(parser.parse('{% verbatim %}{# test {% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output,
+                        [nodes.TemplateData, '{# test ']]]);
+        });
+
+        it('should parse multiple verbatim blocks', function() {
+            isAST(parser.parse('{% verbatim %}{{ var }}{% endverbatim %}{{ var }}{% verbatim %}{{ var }}{% endverbatim %}'),
+                [nodes.Root,
+                    [nodes.Output, [nodes.TemplateData, '{{ var }}']],
+                    [nodes.Output, [nodes.Symbol, 'var']],
+                    [nodes.Output, [nodes.TemplateData, '{{ var }}']]]);
+        });
+
+        it('should parse multiline multiple verbatim blocks', function() {
+            isAST(parser.parse('\n{% verbatim %}{{ var }}{% endverbatim %}\n{{ var }}\n{% verbatim %}{{ var }}{% endverbatim %}\n'),
+                [nodes.Root,
+                    [nodes.Output, [nodes.TemplateData, '\n']],
+                    [nodes.Output, [nodes.TemplateData, '{{ var }}']],
+                    [nodes.Output, [nodes.TemplateData, '\n']],
+                    [nodes.Output, [nodes.Symbol, 'var']],
+                    [nodes.Output, [nodes.TemplateData, '\n']],
+                    [nodes.Output, [nodes.TemplateData, '{{ var }}']],
+                    [nodes.Output, [nodes.TemplateData, '\n']]]);
+        });
+
         it('should parse keyword and non-keyword arguments', function() {
             isAST(parser.parse('{{ foo("bar", falalalala, baz="foobar") }}'),
                   [nodes.Root,


### PR DESCRIPTION
## Summary

Proposed change:

* Add `verbatim` as an alias of `raw` for compatibility with Twig (see [Twig `verbatim` tag](http://twig.sensiolabs.org/doc/tags/verbatim.html)).
* Extends `parseRaw` with `tagName` parameter to support `verbatim`.
* Reuses `raw` tag tests.
* Explains compatibility in docs.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

(Tick of items by replacing `[ ]` by `[x]`)
