### PR TITLE
Fixes regex syntax in docs + add better example

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -772,11 +772,13 @@ normal.
 
 ### Regular Expressions
 
-A regular expression can be created just like JavaScript:
+A regular expression can be created just like JavaScript, but needs to be prefixed with `r`:
 
 ```jinja
-{{ /^foo.*/ }}
-{{ /bar$/g }}
+{% set regExp = r/^foo.*/g %}
+{% if regExp.test('foo') %}
+  Foo in the house!
+{% endif %}
 ```
 
 The supported flags are the following. See


### PR DESCRIPTION
## Summary

Proposed change:

Fix erroneous regular expression syntax in documentation, and add better example of usage.

Closes #881  .
## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.
- [x] Proposed change helps towards [_purpose of this project_](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
- [x] [_Documentation_](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
- [x] [_Tests_](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
- [x] [_Changelog_](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

(Tick of items by replacing `[ ]` by `[x]`)
