### PR TITLE
Add variables whitespace control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Changelog
 * Fix handling of macro arg with default value which shares a name with another
   macro. Merge of [#791](https://github.com/mozilla/nunjucks/pull/791).
 
+* Add variables whitespace control.
+
 
 2.5.2 (Sep 14 2016)
 ----------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -663,7 +663,7 @@ don't want the extra whitespace, but you still want to format the template
 cleanly, which requires whitespace.
 
 You can tell the engine to strip all leading or trailing whitespace by adding a
-minus sign (`-`) to the start or end block tag.
+minus sign (`-`) to the start or end block or a variable.
 
 ```jinja
 {% for i in [1,2,3,4,5] -%}
@@ -673,6 +673,9 @@ minus sign (`-`) to the start or end block tag.
 
 The exact output of the above would be "12345". The `{%-` strips the whitespace
 right before the tag, and `-%}` the strips the whitespace right after the tag.
+
+And the same is for variables: `{{-` will strip the whitespace before the variable,
+and `-}}` will strip the whitespace after the variable.
 
 ## Expressions
 

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -123,7 +123,8 @@ Tokenizer.prototype.nextToken = function() {
             }
             return token(TOKEN_BLOCK_END, tok, lineno, colno);
         }
-        else if((tok = this._extractString(this.tags.VARIABLE_END))) {
+        else if((tok = this._extractString(this.tags.VARIABLE_END)) ||
+                (tok = this._extractString('-' + this.tags.VARIABLE_END))) {
             // Special check for variable end tag (see above)
             this.in_code = false;
             return token(TOKEN_VARIABLE_END, tok, lineno, colno);
@@ -240,7 +241,8 @@ Tokenizer.prototype.nextToken = function() {
             this.in_code = true;
             return token(TOKEN_BLOCK_START, tok, lineno, colno);
         }
-        else if((tok = this._extractString(this.tags.VARIABLE_START))) {
+        else if((tok = this._extractString(this.tags.VARIABLE_START + '-')) ||
+                (tok = this._extractString(this.tags.VARIABLE_START))) {
             this.in_code = true;
             return token(TOKEN_VARIABLE_START, tok, lineno, colno);
         }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1212,7 +1212,7 @@ var Parser = Object.extend({
                     this.dropLeadingWhitespace = false;
                 }
 
-                // Same for the succeding block start token
+                // Same for the succeeding block start token
                 if(nextToken &&
                     ((nextToken.type === lexer.TOKEN_BLOCK_START &&
                       nextVal.charAt(nextVal.length - 1) === '-') ||

--- a/src/parser.js
+++ b/src/parser.js
@@ -129,7 +129,14 @@ var Parser = Object.extend({
     },
 
     advanceAfterVariableEnd: function() {
-        if(!this.skip(lexer.TOKEN_VARIABLE_END)) {
+        var tok = this.nextToken();
+
+        if(tok && tok.type === lexer.TOKEN_VARIABLE_END) {
+            this.dropLeadingWhitespace = tok.value.charAt(
+                tok.value.length - this.tokens.tags.VARIABLE_END.length - 1
+            ) === '-';
+        } else {
+            this.pushToken(tok);
             this.fail('expected variable end');
         }
     },
@@ -1209,6 +1216,9 @@ var Parser = Object.extend({
                 if(nextToken &&
                     ((nextToken.type === lexer.TOKEN_BLOCK_START &&
                       nextVal.charAt(nextVal.length - 1) === '-') ||
+                    (nextToken.type === lexer.TOKEN_VARIABLE_START &&
+                      nextVal.charAt(this.tokens.tags.VARIABLE_START.length)
+                        === '-') ||
                     (nextToken.type === lexer.TOKEN_COMMENT &&
                       nextVal.charAt(this.tokens.tags.COMMENT_START.length)
                         === '-'))) {
@@ -1232,8 +1242,8 @@ var Parser = Object.extend({
             }
             else if(tok.type === lexer.TOKEN_VARIABLE_START) {
                 var e = this.parseExpression();
-                this.advanceAfterVariableEnd();
                 this.dropLeadingWhitespace = false;
+                this.advanceAfterVariableEnd();
                 buf.push(new nodes.Output(tok.lineno, tok.colno, [e]));
             }
             else if(tok.type === lexer.TOKEN_COMMENT) {

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1623,9 +1623,31 @@
               ' hello'
             );
 
+            finish(done);
+        });
+
+        it('should control expression whitespaces correctly', function(done) {
             equal(
                 'Well, {{- \' hello, \' -}} my friend',
                 'Well, hello, my friend'
+            );
+
+            equal(' {{ 2 + 2 }} ', ' 4 ');
+
+            equal(' {{-2 + 2 }} ', '4 ');
+
+            equal(' {{ -2 + 2 }} ', ' 0 ');
+
+            equal(' {{ 2 + 2 -}} ', ' 4');
+
+            render(
+                ' {{ 2 + 2- }}',
+                {},
+                { noThrow: true },
+                function(err, res) {
+                    expect(res).to.be(undefined);
+                    expect(err).to.match(/unexpected token: }}/);
+                }
             );
 
             finish(done);

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1623,6 +1623,11 @@
               ' hello'
             );
 
+            equal(
+                'Well, {{- \' hello, \' -}} my friend',
+                'Well, hello, my friend'
+            );
+
             finish(done);
         });
 


### PR DESCRIPTION
## Summary

Proposed change:

Jinja2 supports whitespace control not only in block tags, but also in variables. It's very, very convenient, otherwise you should use awkward workarounds like `{%- if true -%}…{%- endif -%}` &c. I added whitespace control support in variables.
## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.
- [x] Proposed change helps towards [_purpose of this project_](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
- [x] [_Documentation_](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
- [x] [_Tests_](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
- [x] [_Changelog_](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).
