### PR TITLE
make chokidar an optional dependency

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ directory, and the following options are available in **opts**:
 * **throwOnUndefined** *(default: false)* throw errors when outputting a null/undefined value
 * **trimBlocks** *(default: false)* automatically remove trailing newlines from a block/tag
 * **lstripBlocks** *(default: false)* automatically remove leading whitespace from a block/tag
-* **watch** *(default: false)* reload templates when they are changed (server-side)
+* **watch** *(default: false)* reload templates when they are changed (server-side). To use watch, make sure optional dependency *chokidar* is installed.
 * **noCache** *(default: false)* never use a cache and recompile templates each time (server-side)
 * **web** an object for configuring loading templates in the browser:
   * **useCache** *(default: false)* will enable cache and templates will never see updates.
@@ -402,7 +402,7 @@ templates live, and it defaults to the current working directory.
 
 **opts** is an object with the following optional properties:
 
-* **watch** - if `true`, the system will automatically update templates
+* **watch** - if `true`, the system will automatically update templates. To use watch, make sure optional dependency *chokidar* is installed.
   when they are changed on the filesystem
 * **noCache** - if `true`, the system will avoid using a cache and templates
   will be recompiled every single time

--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -68,7 +68,7 @@ nunjucks.configure([path], [opts]);
 * **throwOnUndefined** *(default: false)* 当输出为 null 或 undefined 会抛出异常
 * **trimBlocks** *(default: false)* 自动去除 block/tag 后面的换行符
 * **lstripBlocks** *(default: false)* 自动去除 block/tag 签名的空格
-* **watch** *(默认值: false)* 当模板变化时重新加载
+* **watch** *(默认值: false)* 当模板变化时重新加载。使用前请确保已安装可选依赖 *chokidar*。
 * **noCache** *(default: false)* 不使用缓存，每次都重新编译
 * **web** 浏览器模块的配置项
   * **useCache** *(default: false)* 是否使用缓存，否则会重新请求下载模板
@@ -323,7 +323,7 @@ new FileSystemLoader([searchPaths], [opt])
 
 **opt** 为一个对象，包含如下属性：
 
-* **watch** - 如果为 `true`，当文件系统上的模板变化了，系统会自动更新他。
+* **watch** - 如果为 `true`，当文件系统上的模板变化了，系统会自动更新他。使用前请确保已安装可选依赖 *chokidar*。
 * **noCache** - 如果为 `true`，不使用缓存，模板每次都会重新编译。
 
 ```js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "a-sync-waterfall": "^1.0.0",
     "asap": "^2.0.3",
-    "chokidar": "^1.6.0",
     "yargs": "^3.32.0"
   },
   "browser": "./browser/nunjucks.js",
@@ -20,6 +19,9 @@
     "supertest": "*",
     "uglify-js": "*",
     "webpack": "^1.8.11"
+  },
+  "optionalDependencies": {
+    "chokidar": "^1.6.0"
   },
   "engines": {
     "node": "*"

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 var lib = require('./lib');
 var Loader = require('./loader');
-var chokidar = require('chokidar');
 var PrecompiledLoader = require('./precompiled-loader.js');
 
 // Node <0.7.1 compatibility
@@ -36,6 +35,7 @@ var FileSystemLoader = Loader.extend({
         if(opts.watch) {
             // Watch all the templates in the paths and fire an event when
             // they change
+            var chokidar = require('chokidar');
             var paths = this.searchPaths.filter(function(p) { return existsSync(p); });
             var watcher = chokidar.watch(paths);
             var _this = this;


### PR DESCRIPTION
## Summary

Proposed change:

Move chokidar to optionalDependencies. Since #610 says `watch: true` is planned to be deprecated in the feature, maybe it's a good start:) This PR is almost identical to #607 which was closed by the author.
People use `npm install` will still install chokidar as a dependency, but not with `npm install --no-optional`. When chokidar not installed but using `watch: true`, process will throw a "Cannot find module" error.

Closes #600.
## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.
- [x] Proposed change helps towards [_purpose of this project_](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
- [x] [_Documentation_](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
- [ ] [_Tests_](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
- [ ] [_Changelog_](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

(Tick of items by replacing `[ ]` by `[x]`)
