### PR TITLE
Adds instance function for cloning environment

### DIFF
--- a/tests/environment.js
+++ b/tests/environment.js
@@ -1,0 +1,69 @@
+(function() {
+    'use strict';
+
+    var expect, Environment;
+
+    if(typeof require !== 'undefined') {
+        expect = require('expect.js');
+        Environment = require('../src/environment').Environment;
+    } else {
+        expect = window.expect;
+        Environment = nunjucks.Environment;
+    }
+
+    describe('Environment', function() {
+        describe('.clone', function() {
+            it('should clone original opts', function() {
+                var original = new Environment(null, { dev: true, trimBlocks: false });
+                var clone = original.clone();
+
+                expect(clone.opts.dev).to.be(true);
+                expect(clone.opts.trimBlocks).to.be(false);
+            });
+
+            it('should copy the default & added filters', function() {
+                var filter = function() {};
+                var original = new Environment();
+                original.addFilter('stuff', filter);
+                var clone = original.clone();
+
+                expect(Object.keys(clone.filters).length).equal(Object.keys(original.filters).length);
+                expect(clone.getFilter('stuff')).equal(filter);
+            });
+
+            it('should copy the default & added globals', function() {
+                var fn = function() {};
+                var original = new Environment();
+                original.addGlobal('stuff', fn);
+                var clone = original.clone();
+
+                expect(Object.keys(clone.globals).length).equal(Object.keys(original.globals).length);
+                expect(clone.getGlobal('stuff')).equal(fn);
+            });
+
+            it('should copy existing extensions', function() {
+                var fn = function() {};
+                var original = new Environment();
+                original.addExtension('stuff', fn);
+                var clone = original.clone();
+
+                expect(Object.keys(clone.extensions).length).equal(1);
+                expect(clone.getExtension('stuff')).equal(fn);
+            });
+
+            it('should clone loaders', function() {
+              var original = new Environment();
+              var originalLoader = original.loaders[0];
+              originalLoader._testMark = true;
+              originalLoader.cache.someTemplate = 'a cache';
+
+              var clone = original.clone();
+
+              expect(clone.loaders.length).equal(1);
+              expect(clone.loaders[0]._testMark).equal(true);
+              expect(Object.keys(clone.loaders[0].cache).length).equal(0);
+              expect(original.loaders[0].cache.someTemplate).equal('a cache');
+            });
+        });
+    });
+})();


### PR DESCRIPTION
## Summary

This is a bit of an RFC implementation because I'm not sure whether it's welcome. For this reason I skipped adding docs and will do so if this goes forward.

We've often had the use case of wanting to extend a nunjucks environment (usually with filters) without affecting other modules using the same "base" env. As it stands we're required to re-configure a new env from scratch and extend that to ensure the new config doesn't leak outside the current point in the code.

This PR adds a `clone` method (alternative name could be `configure`) for, as the name implies, cloning an env. All globals, extensions, filters and loaders are carried over to the new env instance, which is now detached from the original but with the same config.

There are workarounds for this of course, but I think it'd make things a lot easier for this particular use case.
## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.
- [x] Proposed change helps towards [_purpose of this project_](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
- [ ] [_Documentation_](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
- [x] [_Tests_](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
- [ ] [_Changelog_](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).
