### PR TITLE
Add python's list `append` method for Jinja compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,17 @@ Changelog
 * Fix handling of macro arg with default value which shares a name with another
   macro. Merge of [#791](https://github.com/mozilla/nunjucks/pull/791).
 
-* Add support for the spaces parameter in the dump template filter. 
-  Merge of [#868](https://github.com/mozilla/nunjucks/pull/868). 
+* Add support for the spaces parameter in the dump template filter.
+  Merge of [#868](https://github.com/mozilla/nunjucks/pull/868).
   Thanks Jesse Eikema
 
 * Add `verbatim` as an alias of `raw` for compatibility with Twig.
   Merge of [#874](https://github.com/mozilla/nunjucks/pull/874).
 
 * Add new `nl2br` filter. Thanks Marc-Aurèle Darche
+
+* Add support for python's `list.append` with Jinja compat enabled. Thanks
+  Conor Flannigan.
 
 
 
@@ -49,8 +52,8 @@ Changelog
 
 * Fix `undefined` and `null` behavior in escape and safe filter.
   Merge of [#843](https://github.com/mozilla/nunjucks/pull/843).
-  
-  
+
+
 2.5.0 (Sep 7 2016)
 ----------------
 

--- a/src/jinja-compat.js
+++ b/src/jinja-compat.js
@@ -34,6 +34,9 @@ function installCompat() {
       }
       return this.splice(index, 1);
     },
+    append: function(element) {
+        return this.push(element);
+    },
     remove: function(element) {
       for (var i = 0; i < this.length; i++) {
         if (this[i] === element) {


### PR DESCRIPTION
## Summary

Adds python's [list.append](https://docs.python.org/2/library/array.html?highlight=append#array.array.append) for jinja compat.