### PR TITLE
Update docs in french

### DIFF
--- a/docs/fr/api.md
+++ b/docs/fr/api.md
@@ -85,7 +85,7 @@ et les options suivantes sont disponibles dans **opts** :
 * **throwOnUndefined** *(par défaut : false)* lève des erreurs quand le résultat a une valeur null/undefined
 * **trimBlocks** *(par défaut : false)* supprime automatiquement les sauts de lignes de fin de block/tag
 * **lstripBlocks** *(par défaut : false)* supprime automatiquement les espaces de début de block/tag
-* **watch** *(par défaut : false)* recharge les templates quand ils ont été changés (côté serveur)
+* **watch** *(par défaut : false)* recharge les templates quand ils ont été changés (côté serveur). Pour utiliser watch, veuillez vérifier que la dépendance optionnelle *chokidar* soit installée.
 * **noCache** *(par défaut : false)* ne jamais utiliser le cache et recompiler les templates à chaque fois (côté serveur)
 * **web** un objet pour la configuration du chargement des templates dans le navigateur :
   * **useCache** *(par défaut : false)* activera le cache et les templates ne verront jamais les mises à jour.
@@ -402,7 +402,7 @@ tous les templates et il est par défaut dans le répertoire de travail courant.
 
 **opts** est un objet avec les propriétés optionnelles suivantes :
 
-* **watch** - si `true`, le système mettra à jour automatiquement les templates
+* **watch** - si `true`, le système mettra à jour automatiquement les templates. Pour utiliser watch, veuillez vérifier que la dépendance optionnelle *chokidar* soit installée.
   quand ils sont modifiés sur le système de fichiers
 * **noCache** - si `true`, le système évitera l'utilisation d'un cache et les
   templates seront recompilés à chaque fois

--- a/docs/fr/api.md
+++ b/docs/fr/api.md
@@ -475,7 +475,7 @@ var MyLoader = nunjucks.Loader.extend({
         // configure un processus qui regarde ici les templates
         // et appelle `this.emit('update', name)` lorsqu'un template
         // est modifié
-    }
+    },
 
     getSource: function(name) {
         // charge le template

--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -669,7 +669,7 @@ voulez pas les espaces supplémentaires, mais vous voulez continuer à formater 
 proprement, ce qui nécessite des espaces.
 
 Vous pouvez dire au moteur d'enlever les espaces de début et de fin en ajoutant le signe
-moins (`-`) sur le tag de début ou de fin..
+moins (`-`) sur le tag de début ou de fin d'un bloc ou d'une variable.
 
 ```jinja
 {% for i in [1,2,3,4,5] -%}
@@ -679,6 +679,9 @@ moins (`-`) sur le tag de début ou de fin..
 
 L'affichage exact de l'exemple du dessus sera "12345". Le `{%-` enlève les espaces à
 droite avant le tag et le `-%}` enlève les espaces à droite après le tag.
+
+C'est la même chose pour les variables: `{{-` enlève les espaces avant la variable,
+et `-}}` enlève les espaces après la variable.
 
 ## Expressions
 
@@ -778,11 +781,13 @@ normalement.
 
 ### Expressions régulières
 
-Une expression régulière peut être créée comme en JavaScript :
+Une expression régulière peut être créée comme en JavaScript, mais elle a besoin d'être précédée par `r` :
 
 ```jinja
-{{ /^foo.*/ }}
-{{ /bar$/g }}
+{% set regExp = r/^foo.*/g %}
+{% if regExp.test('foo') %}
+  Foo dans la maison !
+{% endif %}
 ```
 
 Les flags supportés sont les suivants. Voir
@@ -1032,6 +1037,7 @@ retournées. Cela rend le résultat plus lisible.
 	}
 ]
 ```
+
 ### escape (aliased as e)
 
 Convertit les caractères &, <, >, â€˜, et â€ dans des chaines avec des séquences HTML sécurisées.
@@ -1307,6 +1313,22 @@ Convertit une chaine en minuscule :
 foobar
 ```
 
+### nl2br
+
+Remplace les nouvelles lignes par des éléments HTML `<br />` :
+
+**Entrée**
+
+```jinja
+{{ "foo\nbar" | striptags(true) | escape | nl2br }}
+```
+
+**Sortie**
+
+```jinja
+foo<br />\nbar
+```
+
 ### random
 
 Sélectionne une valeur aléatoire depuis un tableau.
@@ -1568,7 +1590,6 @@ Découpe un itérateur et retourne une liste de listes contenant ces éléments 
     </ul>
 </div>
 ```
-
 ### sort(arr, reverse, caseSens, attr)
 
 Tri `arr` avec la fonction `arr.sort` de JavaScript. Si `reverse` est à true, le résultat
@@ -1602,8 +1623,8 @@ C'est similaire à
 `preserve_linebreaks` est à false (par défaut), cela enlève les balises SGML/XML et remplace
 les espaces adjacents par un seul espace. Si `preserve_linebreaks` est à true,
 cela normalise les espaces, en essayant de préserver les sauts de lignes originaux. Utiliser le second
-comportement si vous voulez utiliser ceci `{{ text | striptags | nl2br }}`. Sinon
-utilisez le comportement par défaut.
+comportement si vous voulez utiliser ceci `{{ text | striptags(true) | escape | nl2br }}`.
+Sinon utilisez le comportement par défaut.
 
 ### sum
 


### PR DESCRIPTION
## Summary

Proposed change:
Update docs in french


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [X] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.

1. Add nl2br filter (mozilla/nunjucks@2db9e533c6902f962a73fe31f47c281bc4e9017c)
2. Update documentation (mozilla/nunjucks@2a118078534703e7631c1444cc98cea911e16f55)
3. Fixes regex syntax in docs + add better example (mozilla/nunjucks@5dc42ba86424d7fc5cd9f7f4cb0f99bb35c0d210)
4. Make chokidar an optional dependency (mozilla/nunjucks@0cfd6766a05cb72f27afd9e867f9cbb427238511)
5. Docs: add missing comma to API section (mozilla/nunjucks@f015bf9)