### PR TITLE
Add failing test for passing vars from parent macro to child macro.

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -695,6 +695,20 @@
             finish(done);
         });
 
+        it('should allow child macro to access vars set in parent macro', function(done) {
+            equal('{% macro parent() %}' +
+                  '{% set x = "bar" %}' +
+                  '{% macro child() %}' +
+                  '{{ x }}' +
+                  '{% endmacro %}' +
+                  '{{ child() }}' +
+                  '{% endmacro %}' +
+                  '{{ parent() }}',
+                  'bar');
+
+            finish(done);
+        });
+
         it('should import templates', function(done) {
             equal('{% import "import.njk" as imp %}' +
                   '{{ imp.foo() }} {{ imp.bar }}',


### PR DESCRIPTION
This PR simply adds a failing test for the most basic case of #912 (probably also related to #906).