### PR TITLE
Fix static primitives attributes and methods handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 master (unreleased)
 ----------------
 
+* Fix handling of static strings attributes and methods, which partially covers
+ths issue [#791](https://github.com/mozilla/nunjucks/issues/937).
 
 3.0.0 (Nov 5 2016)
 ----------------

--- a/src/parser.js
+++ b/src/parser.js
@@ -965,6 +965,10 @@ var Parser = Object.extend({
 
         if(val !== undefined) {
             node = new nodes.Literal(tok.lineno, tok.colno, val);
+
+            if(!noPostfix) {
+                node = this.parsePostfix(node);
+            }
         }
         else if(tok.type === lexer.TOKEN_SYMBOL) {
             node = new nodes.Symbol(tok.lineno, tok.colno, tok.value);

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -286,6 +286,12 @@
                                  'water{% endif %}?');
             expect(n.children[1].typename).to.be('If');
 
+            n = parser.parse('{% if "some string".length > 10 %}stuff{% endif %}');
+            expect(n.children[0].typename).to.be('If');
+
+            n = parser.parse('{% if 1.618.toFixed(2) == "1.62" %}stuff{% endif %}');
+            expect(n.children[0].typename).to.be('If');
+
             n = parser.parse('{% block foo %}stuff{% endblock %}');
             expect(n.children[0].typename).to.be('Block');
 


### PR DESCRIPTION
## Summary

Proposed change:

This solves the problem of using attributes and methods of static primitive values example :

```
    {{ 1.618.toFixed(2)  }}
    {{ 'some string'.replace(a, b) }}
```
it partially solves #937

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->