### PR TITLE
Fix static values attributes and methods handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 master (unreleased)
 ----------------
 
+* Fix handling methods and attributes of static arrays, objects and primitives.
+  Solves the issue [#937](https://github.com/mozilla/nunjucks/issues/937)
 
 3.0.0 (Nov 5 2016)
 ----------------

--- a/src/parser.js
+++ b/src/parser.js
@@ -968,16 +968,16 @@ var Parser = Object.extend({
         }
         else if(tok.type === lexer.TOKEN_SYMBOL) {
             node = new nodes.Symbol(tok.lineno, tok.colno, tok.value);
-
-            if(!noPostfix) {
-                node = this.parsePostfix(node);
-            }
         }
         else {
             // See if it's an aggregate type, we need to push the
             // current delimiter token back on
             this.pushToken(tok);
             node = this.parseAggregate();
+        }
+
+        if(!noPostfix) {
+            node = this.parsePostfix(node);
         }
 
         if(node) {

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -299,6 +299,28 @@
             expect(n.children[0].typename).to.be('Include');
         });
 
+        it('should accept attributes and methods of static arrays, objects and primitives', function() {
+            expect(function () {
+                parser.parse('{{ ([1, 2, 3]).indexOf(1) }}');
+            }).to.not.throwException();
+
+            expect(function () {
+                parser.parse('{{ [1, 2, 3].length }}');
+            }).to.not.throwException();
+
+            expect(function () {
+                parser.parse('{{ "Some String".replace("S", "$") }}');
+            }).to.not.throwException();
+
+            expect(function () {
+                parser.parse('{{ ({ name : "Khalid" }).name }}');
+            }).to.not.throwException();
+
+            expect(function () {
+                parser.parse('{{ 1.618.toFixed(2) }}');
+            }).to.not.throwException();
+        });
+
         it('should parse include tags', function() {
 
             var n = parser.parse('{% include "test.njk" %}');


### PR DESCRIPTION
## Summary

Proposed change:

This solves the problem of using attributes and methods of static arrays, objects and primitives example:

```
{{ ([1, 2, 3]).indexOf(a) }}
{{ 'Some String'.replace(a, b) }}
{{ ({ a : 123 }).a }}
{{ 1.618.toFixed(2) }}
```
Closes #937.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->