### PR TITLE
Fix undefined template string

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -50,6 +50,10 @@ function token(type, value, lineno, colno) {
 }
 
 function Tokenizer(str, opts) {
+    if (typeof str !== 'string') {
+      throw new lib.TemplateError(str + ' is not a valid template string.');
+    }
+    
     this.str = str;
     this.index = 0;
     this.len = str.length;

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -831,6 +831,10 @@
             expect(function() {
                 parser.parse('{% from "foo" import _bar %}');
             }).to.throwException(/names starting with an underscore cannot be imported/);
+
+            expect(function() {
+                parser.parse(undefined);
+            }).to.throwException(/undefined is not a valid template string/);
         });
 
         it('should parse custom tags', function() {


### PR DESCRIPTION
## Summary

Proposed change:

The test cases for parser missed the case when a template string is ``undefined``. An ``undefined`` string can cause the following hard crash.

```
TypeError: Cannot read property 'length' of undefined
    at new Tokenizer (/path/nunjucks.js:3989:20)
    at Object.lex (/path/nunjucks.js:4427:17)
    at Object.parse (/path/nunjucks.js:3922:35)
```

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

Closes # .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->