### PR TITLE
Fix missing `}}` in templating.md

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1487,7 +1487,7 @@ Round to the nearest whole number (which rounds down):
 **Input**
 
 ```jinja
-{{ 4 | round(0, "floor")
+{{ 4 | round(0, "floor") }}
 ```
 
 **Output**


### PR DESCRIPTION
## Summary

Proposed change:

Given all of the other examples, this input for the round filter `{{ 4 | round(0, "floor")` most likely should be `{{ 4 | round(0, "floor") }}`

## Checklist

I don't know that any tests need to be updated for this. Better documentation is always in the best interest of the project. Fixing documentation most likely does not need to go in the changelog. 

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [X] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [X] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [X] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [X] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->