### PR TITLE
[WIP] Expose kwargs variable in macros context like jinja2

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -833,6 +833,12 @@ var Compiler = Object.extend({
             'var callerFrame = frame;',
             'frame = new runtime.Frame();',
             'kwargs = kwargs || {};',
+            // Expose kwargs variable in the context like Jinja2 macros.
+            'var kwargs_variable = Object.assign({}, kwargs);',
+            'delete kwargs_variable.__keywords;',
+            'delete kwargs_variable.caller;',
+            'frame.set("kwargs", kwargs_variable);',
+            // Expose caller variable in the context like Jinja2 macros.
             'if (kwargs.hasOwnProperty("caller")) {',
             'frame.set("caller", kwargs.caller); }'
         );


### PR DESCRIPTION
## Summary

Proposed change:

This is a partial PR to discuss support for Jinja2's "special" macro variables `varargs` and `kwargs` (http://jinja.pocoo.org/docs/2.9/templates/#macros). Those variables, along with `caller` that Nunjucks supports already, are available in the context of a macro under specific conditions.

I'm unsure whether this is something Nunjucks wants to support (see #8), so at the moment this PR only adds very basic support for `kwargs`, adding the variable in the macro context but not fully conforming to the Jinja2 semantics. I'm keen to implement this more properly if there is agreement that this is valuable.

## Checklist

I haven't done any of this yet. For example the current implementation won't work in IE8 / Node 0.10 due to the use of `Object.assign`, so this will have to be changed.

~I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.~

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).