### PR TITLE
Gives the green code color (in snippets) proper contrast ratio

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -368,7 +368,7 @@ pre {
 }
 
 #home pre span {
-    color: rgb(30, 150, 50);
+    color: #104f1b;
 }
 
 section.whos-using h4 {


### PR DESCRIPTION
## Summary

Proposed change:

A simple color change of the `span` element of the code blocks, which would bring the contrast ratio in line with WCAG standards and make the snippets more accessible for users with visual impairments.  Only one line of CSS would be changed, nothing else.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->