### PR TITLE
Add python slice support to jinja-compat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ master (unreleased)
 
 * Fix handling methods and attributes of static arrays, objects and primitives.
   Solves the issue [#937](https://github.com/mozilla/nunjucks/issues/937)
+* Add support for python-style array slices with Jinja compat enabled. Thanks
+  Frankie Dintino.
 
 3.0.0 (Nov 5 2016)
 ----------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Nunjucks has the following purpose:
 
 Notes:
 
-* We don't aim for parity of language specific syntax like Python's splice notation `{{ foo[start:end:step] }}`.
+* We don't aim for parity of all language specific syntax.
 * We don't aim for parity of language specific filters like [Twig's PHP date format](http://twig.sensiolabs.org/doc/functions/date.html).
 
 Issues and pull requests contributing to this purpose have the best chance to make it into Nunjucks.

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,8 +135,9 @@ nunjucks does not aim for complete Jinja/Python compatibility, this
 might help users seeking just that.
 
 This adds `True` and `False` which map to the JS `true` and `false`
-values, as well as augmenting arrays and objects with Python-style
-methods. [Check out the source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
+values, allows use of Python slice syntax, and augments arrays and
+objects with Python-style methods.
+[Check out the source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
 to see everything it adds.
 {% endapi %}
 {% raw %}

--- a/docs/fr/api.md
+++ b/docs/fr/api.md
@@ -135,8 +135,9 @@ ne visent pas une compatibilité complète de Jinja/Python, cela pourra
 aider les utilisateurs qui le recherchent au plus juste.
 
 Cela ajoute `True` et `False` qui correspond aux valeurs `true` et `false`
-de JS, ainsi cela se rapproche des tableaux et des objets pour les méthodes avec un style
-Python. [Vérifiez la source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
+de JS. En plus, cela se rapproche des tableaux et des objets pour les méthodes
+avec un style Python et permet également l'utilisation de la syntaxe "slice" Python.
+[Vérifiez la source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
 pour voir tout ce qu'il ajoute.
 {% endapi %}
 {% raw %}

--- a/src/jinja-compat.js
+++ b/src/jinja-compat.js
@@ -1,159 +1,159 @@
 function installCompat() {
-  'use strict';
+    'use strict';
 
-  // This must be called like `nunjucks.installCompat` so that `this`
-  // references the nunjucks instance
-  var runtime = this.runtime; // jshint ignore:line
-  var lib = this.lib; // jshint ignore:line
+    // This must be called like `nunjucks.installCompat` so that `this`
+    // references the nunjucks instance
+    var runtime = this.runtime; // jshint ignore:line
+    var lib = this.lib; // jshint ignore:line
 
-  var orig_contextOrFrameLookup = runtime.contextOrFrameLookup;
-  runtime.contextOrFrameLookup = function(context, frame, key) {
-    var val = orig_contextOrFrameLookup.apply(this, arguments);
-    if (val === undefined) {
-      switch (key) {
-      case 'True':
-        return true;
-      case 'False':
-        return false;
-      case 'None':
-        return null;
-      }
-    }
-
-    return val;
-  };
-
-  var orig_memberLookup = runtime.memberLookup;
-  var ARRAY_MEMBERS = {
-    pop: function(index) {
-      if (index === undefined) {
-        return this.pop();
-      }
-      if (index >= this.length || index < 0) {
-        throw new Error('KeyError');
-      }
-      return this.splice(index, 1);
-    },
-    append: function(element) {
-        return this.push(element);
-    },
-    remove: function(element) {
-      for (var i = 0; i < this.length; i++) {
-        if (this[i] === element) {
-          return this.splice(i, 1);
+    var orig_contextOrFrameLookup = runtime.contextOrFrameLookup;
+    runtime.contextOrFrameLookup = function(context, frame, key) {
+        var val = orig_contextOrFrameLookup.apply(this, arguments);
+        if (val === undefined) {
+            switch (key) {
+            case 'True':
+                return true;
+            case 'False':
+                return false;
+            case 'None':
+                return null;
+            }
         }
-      }
-      throw new Error('ValueError');
-    },
-    count: function(element) {
-      var count = 0;
-      for (var i = 0; i < this.length; i++) {
-        if (this[i] === element) {
-          count++;
+
+        return val;
+    };
+
+    var orig_memberLookup = runtime.memberLookup;
+    var ARRAY_MEMBERS = {
+        pop: function(index) {
+            if (index === undefined) {
+                return this.pop();
+            }
+            if (index >= this.length || index < 0) {
+                throw new Error('KeyError');
+            }
+            return this.splice(index, 1);
+        },
+        append: function(element) {
+                return this.push(element);
+        },
+        remove: function(element) {
+            for (var i = 0; i < this.length; i++) {
+                if (this[i] === element) {
+                    return this.splice(i, 1);
+                }
+            }
+            throw new Error('ValueError');
+        },
+        count: function(element) {
+            var count = 0;
+            for (var i = 0; i < this.length; i++) {
+                if (this[i] === element) {
+                    count++;
+                }
+            }
+            return count;
+        },
+        index: function(element) {
+            var i;
+            if ((i = this.indexOf(element)) === -1) {
+                throw new Error('ValueError');
+            }
+            return i;
+        },
+        find: function(element) {
+            return this.indexOf(element);
+        },
+        insert: function(index, elem) {
+            return this.splice(index, 0, elem);
         }
-      }
-      return count;
-    },
-    index: function(element) {
-      var i;
-      if ((i = this.indexOf(element)) === -1) {
-        throw new Error('ValueError');
-      }
-      return i;
-    },
-    find: function(element) {
-      return this.indexOf(element);
-    },
-    insert: function(index, elem) {
-      return this.splice(index, 0, elem);
-    }
-  };
-  var OBJECT_MEMBERS = {
-    items: function() {
-      var ret = [];
-      for(var k in this) {
-        ret.push([k, this[k]]);
-      }
-      return ret;
-    },
-    values: function() {
-      var ret = [];
-      for(var k in this) {
-        ret.push(this[k]);
-      }
-      return ret;
-    },
-    keys: function() {
-      var ret = [];
-      for(var k in this) {
-        ret.push(k);
-      }
-      return ret;
-    },
-    get: function(key, def) {
-      var output = this[key];
-      if (output === undefined) {
-        output = def;
-      }
-      return output;
-    },
-    has_key: function(key) {
-      return this.hasOwnProperty(key);
-    },
-    pop: function(key, def) {
-      var output = this[key];
-      if (output === undefined && def !== undefined) {
-        output = def;
-      } else if (output === undefined) {
-        throw new Error('KeyError');
-      } else {
-        delete this[key];
-      }
-      return output;
-    },
-    popitem: function() {
-      for (var k in this) {
-        // Return the first object pair.
-        var val = this[k];
-        delete this[k];
-        return [k, val];
-      }
-      throw new Error('KeyError');
-    },
-    setdefault: function(key, def) {
-      if (key in this) {
-        return this[key];
-      }
-      if (def === undefined) {
-        def = null;
-      }
-      return this[key] = def;
-    },
-    update: function(kwargs) {
-      for (var k in kwargs) {
-        this[k] = kwargs[k];
-      }
-      return null;  // Always returns None
-    }
-  };
-  OBJECT_MEMBERS.iteritems = OBJECT_MEMBERS.items;
-  OBJECT_MEMBERS.itervalues = OBJECT_MEMBERS.values;
-  OBJECT_MEMBERS.iterkeys = OBJECT_MEMBERS.keys;
-  runtime.memberLookup = function(obj, val, autoescape) { // jshint ignore:line
-    obj = obj || {};
+    };
+    var OBJECT_MEMBERS = {
+        items: function() {
+            var ret = [];
+            for(var k in this) {
+                ret.push([k, this[k]]);
+            }
+            return ret;
+        },
+        values: function() {
+            var ret = [];
+            for(var k in this) {
+                ret.push(this[k]);
+            }
+            return ret;
+        },
+        keys: function() {
+            var ret = [];
+            for(var k in this) {
+                ret.push(k);
+            }
+            return ret;
+        },
+        get: function(key, def) {
+            var output = this[key];
+            if (output === undefined) {
+                output = def;
+            }
+            return output;
+        },
+        has_key: function(key) {
+            return this.hasOwnProperty(key);
+        },
+        pop: function(key, def) {
+            var output = this[key];
+            if (output === undefined && def !== undefined) {
+                output = def;
+            } else if (output === undefined) {
+                throw new Error('KeyError');
+            } else {
+                delete this[key];
+            }
+            return output;
+        },
+        popitem: function() {
+            for (var k in this) {
+                // Return the first object pair.
+                var val = this[k];
+                delete this[k];
+                return [k, val];
+            }
+            throw new Error('KeyError');
+        },
+        setdefault: function(key, def) {
+            if (key in this) {
+                return this[key];
+            }
+            if (def === undefined) {
+                def = null;
+            }
+            return this[key] = def;
+        },
+        update: function(kwargs) {
+            for (var k in kwargs) {
+                this[k] = kwargs[k];
+            }
+            return null;    // Always returns None
+        }
+    };
+    OBJECT_MEMBERS.iteritems = OBJECT_MEMBERS.items;
+    OBJECT_MEMBERS.itervalues = OBJECT_MEMBERS.values;
+    OBJECT_MEMBERS.iterkeys = OBJECT_MEMBERS.keys;
+    runtime.memberLookup = function(obj, val, autoescape) { // jshint ignore:line
+        obj = obj || {};
 
-    // If the object is an object, return any of the methods that Python would
-    // otherwise provide.
-    if (lib.isArray(obj) && ARRAY_MEMBERS.hasOwnProperty(val)) {
-      return function() {return ARRAY_MEMBERS[val].apply(obj, arguments);};
-    }
+        // If the object is an object, return any of the methods that Python would
+        // otherwise provide.
+        if (lib.isArray(obj) && ARRAY_MEMBERS.hasOwnProperty(val)) {
+            return function() {return ARRAY_MEMBERS[val].apply(obj, arguments);};
+        }
 
-    if (lib.isObject(obj) && OBJECT_MEMBERS.hasOwnProperty(val)) {
-      return function() {return OBJECT_MEMBERS[val].apply(obj, arguments);};
-    }
+        if (lib.isObject(obj) && OBJECT_MEMBERS.hasOwnProperty(val)) {
+            return function() {return OBJECT_MEMBERS[val].apply(obj, arguments);};
+        }
 
-    return orig_memberLookup.apply(this, arguments);
-  };
+        return orig_memberLookup.apply(this, arguments);
+    };
 }
 
 module.exports = installCompat;

--- a/src/parser.js
+++ b/src/parser.js
@@ -1294,5 +1294,6 @@ module.exports = {
             p.extensions = extensions;
         }
         return p.parseAsRoot();
-    }
+    },
+    Parser: Parser
 };

--- a/tests/jinja-compat.js
+++ b/tests/jinja-compat.js
@@ -1,0 +1,100 @@
+(function() {
+    'use strict';
+
+    var nunjucks, util;
+
+    if(typeof require !== 'undefined') {
+        nunjucks = require('../index.js');
+        util = require('./util');
+    }
+    else {
+        nunjucks = window.nunjucks;
+        util = window.util;
+    }
+
+    var equal = util.jinjaEqual;
+    var finish = util.finish;
+
+    describe('jinja-compat', function() {
+        var arr = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+
+        it('should support array slices with start and stop', function(done) {
+            equal('{% for i in arr[1:4] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'bcd');
+            finish(done);
+        });
+        it('should support array slices using expressions', function(done) {
+            equal('{% for i in arr[n:n+3] %}{{ i }}{% endfor %}',
+                  { n: 1, arr: arr },
+                  'bcd');
+            finish(done);
+        });
+        it('should support array slices with start', function(done) {
+            equal('{% for i in arr[3:] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'defgh');
+            finish(done);
+        });
+        it('should support array slices with negative start', function(done) {
+            equal('{% for i in arr[-3:] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'fgh');
+            finish(done);
+        });
+        it('should support array slices with stop', function(done) {
+            equal('{% for i in arr[:4] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'abcd');
+            finish(done);
+        });
+        it('should support array slices with negative stop', function(done) {
+            equal('{% for i in arr[:-3] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'abcde');
+            finish(done);
+        });
+        it('should support array slices with step', function(done) {
+            equal('{% for i in arr[::2] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'aceg');
+            finish(done);
+        });
+        it('should support array slices with negative step', function(done) {
+            equal('{% for i in arr[::-1] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'hgfedcba');
+            finish(done);
+        });
+        it('should support array slices with start and negative step', function(done) {
+            equal('{% for i in arr[4::-1] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'edcba');
+            finish(done);
+        });
+        it('should support array slices with negative start and negative step', function(done) {
+            equal('{% for i in arr[-5::-1] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'dcba');
+            finish(done);
+        });
+        it('should support array slices with stop and negative step', function(done) {
+            equal('{% for i in arr[:3:-1] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'hgfe');
+            finish(done);
+        });
+        it('should support array slices with start and step', function(done) {
+            equal('{% for i in arr[1::2] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'bdfh');
+            finish(done);
+        });
+        it('should support array slices with start, stop, and step', function(done) {
+            equal('{% for i in arr[1:7:2] %}{{ i }}{% endfor %}',
+                  { arr: arr },
+                  'bdf');
+            finish(done);
+        });
+    });
+})();

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,22 +1,21 @@
 (function() {
     'use strict';
 
-    var Environment, Template, Loader, templatesPath, expect;
+    var nunjucks, Environment, Template, Loader, templatesPath, expect;
 
     if(typeof require !== 'undefined') {
-        Environment = require('../src/environment').Environment;
-        Template = require('../src/environment').Template;
-        Loader = require('../src/node-loaders').FileSystemLoader;
+        nunjucks = require('../index.js');
+        Loader = nunjucks.FileSystemLoader;
         templatesPath = 'tests/templates';
         expect = require('expect.js');
     }
     else {
-        Environment = nunjucks.Environment;
-        Template = nunjucks.Template;
         Loader = nunjucks.WebLoader;
         templatesPath = '../templates';
         expect = window.expect;
     }
+    Environment = nunjucks.Environment;
+    Template = nunjucks.Template;
 
     var numAsyncs;
     var doneHandler;
@@ -35,6 +34,15 @@
 
         var res = render(str, ctx, {}, env);
         expect(res).to.be(str2);
+    }
+
+    function jinjaEqual(str, ctx, str2, env) {
+        var jinjaUninstall = nunjucks.installJinjaCompat();
+        try {
+            return equal(str, ctx, str2, env);
+        } finally {
+            jinjaUninstall();
+        }
     }
 
     function finish(done) {
@@ -118,6 +126,7 @@
     if(typeof module !== 'undefined') {
         module.exports.render = render;
         module.exports.equal = equal;
+        module.exports.jinjaEqual = jinjaEqual;
         module.exports.finish = finish;
         module.exports.normEOL = normEOL;
     }
@@ -125,6 +134,7 @@
         window.util = {
             render: render,
             equal: equal,
+            jinjaEqual: jinjaEqual,
             finish: finish,
             normEOL: normEOL
         };


### PR DESCRIPTION
## Summary

Proposed change:

This pull-request adds support for python-style slice support (e.g. `arr[start:stop:step]`).

`jinja-compat.js` is the only file in this project that indents with two spaces, so my first commit changes it to four-space indent to bring it in conformity with the rest of the project.

There were not any existing tests for jinja compatibility, so I had to make some slight changes to the unit tests to have it work. Part of these changes was having `nunjucks.installJinjaCompat` return a function that, when called, undoes the jinja-compat changes, so that the jinja changes did not apply to other unit tests in the test suite. I wasn't sure if this was worth documenting in the API, since it strikes me as something that is unlikely to be used outside of the tests, but I would be happy to do so if requested.

Closes #188  .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

With regard to the first bullet point above, support for python slice syntax is expressly listed as a feature which falls outside the purpose of Nunjucks. But the same developer that wrote that statement of purpose also suggested in #188 that, if this functionality were to be added, it should be added to jinja-compat. So I assumed that means that while it shouldn't be assumed that nunjucks would support language-specific syntax, it isn't forbidden either. Under this assumption I've added that clarification to the purpose section of CONTRIBUTING.md.