### PR TITLE
Allow {% call %} blocks to access parent scope. Fixes #906

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1700,5 +1700,43 @@
 
             finish(done);
         });
+
+        it('should allow access to outer scope in call blocks', function(done) {
+            render(
+                '{% macro inside() %}' +
+                '{{ caller() }}' +
+                '{% endmacro %}' +
+                '{% macro outside(var) %}' +
+                '{{ var }}\n' +
+                '{% call inside() %}' +
+                '{{ var }}' +
+                '{% endcall %}' +
+                '{% endmacro %}' +
+                '{{ outside("foobar") }}', {}, {}, function(err, res) {
+                    expect(res.trim()).to.eql('foobar\nfoobar');
+            });
+
+            finish(done);
+        });
+
+        it('should not leak scope from call blocks to parent', function(done) {
+            render(
+                '{% set var = "expected" %}' +
+                '{% macro inside() %}' +
+                '{% set var = "incorrect-value" %}' +
+                '{{ caller() }}' +
+                '{% endmacro %}' +
+                '{% macro outside() %}' +
+                '{% call inside() %}' +
+                '{% endcall %}' +
+                '{% endmacro %}' +
+                '{{ outside() }}' +
+                '{{ var }}', {}, {}, function(err, res) {
+                    expect(res.trim()).to.eql('expected');
+            });
+
+            finish(done);
+        });
+
     });
 })();


### PR DESCRIPTION
## Summary

Proposed change:

Allows access to parent scope inside `{% call %}` tags.

Closes #960 .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->