### PR TITLE
Add VSCode editor plugin link

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -31,6 +31,7 @@ Plugins are available in various editors to support the `jinja` syntax highlight
 * brackets <https://github.com/axelboc/nunjucks-brackets>
 * sublime <https://github.com/mogga/sublime-nunjucks/blob/master/Nunjucks.tmLanguage>
 * emacs <http://web-mode.org>
+* vscode <https://marketplace.visualstudio.com/items?itemName=ronnidc.nunjucks>
 
 ## Variables
 


### PR DESCRIPTION
## Summary
This is the only plugin I found and use for VSCode

Proposed change:

<!--
	Just add a link for the VSCode Nunjucks syntax highlighting extension.
-->

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->