### PR TITLE
Add source for TemplateError in renderString

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -324,7 +324,7 @@ var Environment = Obj.extend({
         }
         opts = opts || {};
 
-        var tmpl = new Template(src, this, opts.path);
+        var tmpl = new Template(src, this, opts.path || ('Source:' + src));
         return tmpl.render(ctx, cb);
     },
 


### PR DESCRIPTION
## Summary

Proposed change: replace "unknown path" with source when rendering template string so when a rendering error occurs, it provides way more sense.

Compare the original error message to the new one:

```
Template render error: (unknown path) [Line 10, Column 76]
```

**vs**

```
Template render error: (Source: <p>Template text {{goes here}}</p>) [Line 10, Column 76]
```