### PR TITLE
Fix multiple callback calls, issue #1029

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ Changelog
 master (unreleased)
 -------------------
 
+* Fix calling render callback twice when a conditional import throws an error.
+  Solves [#1029](https://github.com/mozilla/nunjucks/issues/1029)
+
 * Support objects created with Object.create(null). fixes [#468](https://github.com/mozilla/nunjucks/issues/468)
-  
+
 
 3.0.1 (May 24 2017)
 -------------------

--- a/src/environment.js
+++ b/src/environment.js
@@ -152,12 +152,12 @@ var Environment = Obj.extend({
         }
         return this.filters[name];
     },
-    
+
     addTest: function(name, func) {
         this.tests[name] = func;
         return this;
     },
-    
+
     getTest: function(name) {
         if(!this.tests[name]) {
             throw new Error('test not found: ' + name);
@@ -495,6 +495,7 @@ Template = Obj.extend({
         var frame = parentFrame ? parentFrame.push(true) : new Frame();
         frame.topLevel = true;
         var syncResult = null;
+        var didError = false;
 
         _this.rootRenderFunc(
             _this.env,
@@ -502,8 +503,13 @@ Template = Obj.extend({
             frame || new Frame(),
             runtime,
             function(err, res) {
+                if (didError) {
+                    // prevent multiple calls to cb
+                    return;
+                }
                 if(err) {
                     err = lib.prettifyError(_this.path, _this.env.opts.dev, err);
+                    didError = true;
                 }
 
                 if(cb) {

--- a/tests/api.js
+++ b/tests/api.js
@@ -44,6 +44,17 @@
             expect(util.normEOL(test.render())).to.be('Test1\nTest2');
         });
 
+        it('should only call the callback once when conditional import fails', function(done) {
+            var env = new Environment(new Loader(templatesPath));
+            var called = 0;
+            env.render('broken-conditional-include.njk',
+              function() {
+                expect(++called).to.be(1);
+              }
+            );
+            setTimeout(done, 0);
+        });
+
         it('should handle correctly relative paths in renderString', function() {
             var env = new Environment(new Loader(templatesPath));
             expect(env.renderString('{% extends "./relative/test1.njk" %}{% block block1 %}Test3{% endblock %}', {}, {

--- a/tests/templates/broken-conditional-include.njk
+++ b/tests/templates/broken-conditional-include.njk
@@ -1,0 +1,3 @@
+{% if not whatever %}
+    {% include "throws.njk" %}
+{% endif %}

--- a/tests/templates/throws.njk
+++ b/tests/templates/throws.njk
@@ -1,0 +1,1 @@
+{{ nonExistentFn() }}


### PR DESCRIPTION
## Summary

Proposed change:

Fix an issue where an error thrown from a conditionally included template will call the provided callback twice. See the included test for details; fails against master but passes with this change.

Closes #1029 


## Checklist
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).