### PR TITLE
Add support for ES iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ master (unreleased)
 
 * Support objects created with Object.create(null). fixes [#468](https://github.com/mozilla/nunjucks/issues/468)
 
+* Support ESNext iterators, using Array.from. Merge of
+  [#760](https://github.com/mozilla/nunjucks/pull/760)
 
 3.0.1 (May 24 2017)
 -------------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -252,6 +252,23 @@ var food = {
 The [`dictsort`](http://jinja.pocoo.org/docs/templates/#dictsort) filter is
 available for sorting objects when iterating over them.
 
+ES iterators are supported, like the new builtin Map and Set. But also
+anything implementing the iterator protocal.
+
+```js
+var fruits = new Map([
+  ["banana", "yellow"],
+  ["apple", "red"],
+  ["peach", "pink"]
+])
+```
+
+```jinja
+{% for fruit, color in fruits %}
+  Did you know that {{ fruit }} is {{ color }}?
+{% endfor %}
+```
+
 Additionally, Nunjucks will unpack arrays into variables:
 
 ```js

--- a/nunjucks/src/compiler.js
+++ b/nunjucks/src/compiler.js
@@ -662,6 +662,7 @@ class Compiler extends Obj {
     this.emitLine(';');
 
     this.emit(`if(${arr}) {`);
+    this.emitLine(arr + ' = runtime.fromIterator(' + arr + ');');
 
     // If multiple names are passed, we need to bind them
     // appropriately
@@ -754,9 +755,9 @@ class Compiler extends Obj {
 
     this.emitLine('frame = frame.push();');
 
-    this.emit('var ' + arr + ' = ');
+    this.emit('var ' + arr + ' = runtime.fromIterator(');
     this._compileExpression(node.arr, frame);
-    this.emitLine(';');
+    this.emitLine(');');
 
     if (node.name instanceof nodes.Array) {
       const arrayLen = node.name.children.length;

--- a/nunjucks/src/runtime.js
+++ b/nunjucks/src/runtime.js
@@ -1,6 +1,11 @@
 'use strict';
 
 var lib = require('./lib');
+var arrayFrom = Array.from;
+var supportsIterators = (
+  typeof Symbol === 'function' && Symbol.iterator && typeof arrayFrom === 'function'
+);
+
 
 // Frames keep track of scoping both at compile-time and run-time so
 // we know how to access variables. Block tags can introduce special
@@ -342,6 +347,16 @@ function asyncAll(arr, dimen, func, cb) {
   }
 }
 
+function fromIterator(arr) {
+  if (arr == null || lib.isArray(arr)) {
+    return arr;
+  } else if (supportsIterators && Symbol.iterator in arr) {
+    return arrayFrom(arr);
+  } else {
+    return arr;
+  }
+}
+
 module.exports = {
   Frame: Frame,
   makeMacro: makeMacro,
@@ -360,5 +375,6 @@ module.exports = {
   markSafe: markSafe,
   asyncEach: asyncEach,
   asyncAll: asyncAll,
-  inOperator: lib.inOperator
+  inOperator: lib.inOperator,
+  fromIterator: fromIterator
 };

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -475,6 +475,42 @@
             },
             'showing test\nshowing 1\nshowing 2\nshowing 3\n');
         });
+        /* global Set */
+        it('should work with Set builtin', function() {
+          if (typeof Set === 'undefined') {
+            this.skip();
+          } else {
+            equal('{% ' + block + ' i in set %}{{ i }}{% ' + end + ' %}',
+              { set: new Set([1, 2, 3, 4, 5]) },
+              '12345');
+
+            equal('{% ' + block + ' i in set %}{{ i }}{% else %}empty{% ' + end + ' %}',
+              { set: new Set([1, 2, 3, 4, 5]) },
+              '12345');
+
+            equal('{% ' + block + ' i in set %}{{ i }}{% else %}empty{% ' + end + ' %}',
+              { set: new Set() },
+              'empty');
+          }
+        });
+        /* global Map */
+        it('should work with Map builtin', function() {
+          if (typeof Map === 'undefined') {
+            this.skip();
+          } else {
+            equal('{% ' + block + ' k, v in map %}[{{ k }},{{ v }}]{% ' + end + ' %}',
+              { map: new Map([[1, 2], [3, 4], [5, 6]]) },
+              '[1,2][3,4][5,6]');
+
+            equal('{% ' + block + ' k, v in map %}[{{ k }},{{ v }}]{% else %}empty{% ' + end + ' %}',
+              { map: new Map([[1, 2], [3, 4], [5, 6]]) },
+              '[1,2][3,4][5,6]');
+
+            equal('{% ' + block + ' k, v in map %}[{{ k }},{{ v }}]{% else %}empty{% ' + end + ' %}',
+              { map: new Map() },
+              'empty');
+          }
+        });
       });
     }
 


### PR DESCRIPTION
## Summary

Proposed change:

This requires the Symbol.iterator well known symbol and Array.from to coerce them into vanilla arrays.

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

This basically supersedes #760, see there for more info.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->