### PR TITLE
Fix documentation

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -926,8 +926,9 @@ Return a list of lists with the given number of items:
 
 ```jinja
 {% set items = [1,2,3,4,5,6] %}
+{% set dash = joiner("-") %}
 {% for item in items | batch(2) %}
-    -{% for items in item %}
+    {{ dash() }} {% for items in item %}
        {{ items }}
     {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary

Proposed change:
- The documentation shows a loop for a batch using a dash before an element, but the shown output suggests that a joiner was used
- This PR defines a joiner for the batch loop

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

Closes none


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.

<!-- Tick of items by replacing `[ ]` by `[x]` -->