### PR TITLE
Removed chokidar from optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^3.10.0"
   },
-  "optionalDependencies": {
-    "chokidar": "^1.6.0"
-  },
   "_moduleAliases": {
     "babel-register": "@babel/register"
   },


### PR DESCRIPTION
`chokidar` is listed under dependencies and optional dependencies, but it's not optional (gets used in `node-loaders.js`). It's currently not possible to use Nunjucks with `npm --no-optional` as it will throw an `Cannot find module 'chokidar'` error.