### PR TITLE
Update API and Templating docs to use correct path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -148,7 +148,7 @@ might help users seeking just that.
 This adds `True` and `False` which map to the JS `true` and `false`
 values, allows use of Python slice syntax, and augments arrays and
 objects with Python-style methods.
-[Check out the source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
+[Check out the source](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/jinja-compat.js)
 to see everything it adds.
 {% endapi %}
 {% raw %}
@@ -894,7 +894,7 @@ you'll want to use:
 
 The parser API needs to be more documented, but for now read the above
 and check out the example below. You can also look at the
-[source](https://github.com/mozilla/nunjucks/blob/master/src/parser.js).
+[source](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/parser.js).
 
 The most common usage is to process the content within some tags at
 runtime. It's like filters, but on steroids because you aren't

--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -106,7 +106,7 @@ nunjucks.installJinjaCompat()
 
 这个方法为了与 Jinja 更好的兼容，增加了一些适配 Python 的 API。但是 nunjucks 不是为了完全兼容 Jinja/Pyhton，这只为了帮助使用者查看。
 
-增加了 `True` 和 `False`，与 js 的 `true` 和 `false` 相对应。并增加 Array 和 Object 使之适配 Python 风格的。[查看源码](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)能看到所有功能。
+增加了 `True` 和 `False`，与 js 的 `true` 和 `false` 相对应。并增加 Array 和 Object 使之适配 Python 风格的。[查看源码](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/jinja-compat.js)能看到所有功能。
 {% endapi %}
 {% raw %}
 
@@ -663,7 +663,7 @@ env.render('{{ item|lookup }}', function(err, res) {
 
 * `parseUntilBlocks(names)` - 解析内容直到下一个名为 `names` 的标签，非常有用解析标签之间的内容。
 
-parser API 还需要更多的文档，但现在对照上面的文档和下面的例子，你还可以看下[源码](https://github.com/mozilla/nunjucks/blob/master/src/parser.js)。
+parser API 还需要更多的文档，但现在对照上面的文档和下面的例子，你还可以看下[源码](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/parser.js)。
 
 最常用使用的是在运行时解析标签间的内容，就像过滤器一样，但是更灵活，因为不只是局限在一个表达式中。通常情况下你会解析模板，然后将内容传入回调。你可以使用 `CallExtension`，需要传扩展的实例，方法名，解析的参数和内容（使用 `parseUntilBlocks` 解析的）。
 

--- a/docs/cn/templating.md
+++ b/docs/cn/templating.md
@@ -784,6 +784,6 @@ Nunjucks已经实现了jinja中的大部分过滤器，同时也新增了一些�
 * [urlize](http://jinja.pocoo.org/docs/templates/#urlize)
 * [wordcount](http://jinja.pocoo.org/docs/templates/#wordcount)
 
-你也可以直接[看代码](https://github.com/mozilla/nunjucks/blob/master/src/filters.js)。
+你也可以直接[看代码](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/filters.js)。
 
 {% endraw %}

--- a/docs/fr/api.md
+++ b/docs/fr/api.md
@@ -137,7 +137,7 @@ aider les utilisateurs qui le recherchent au plus juste.
 Cela ajoute `True` et `False` qui correspond aux valeurs `true` et `false`
 de JS. En plus, cela se rapproche des tableaux et des objets pour les méthodes
 avec un style Python et permet également l'utilisation de la syntaxe "slice" Python.
-[Vérifiez la source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js)
+[Vérifiez la source](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/jinja-compat.js)
 pour voir tout ce qu'il ajoute.
 {% endapi %}
 {% raw %}
@@ -883,7 +883,7 @@ que vous aurez besoin d'utiliser :
 
 L'API de l'analyseur doit être plus documenté, mais pour l'instant lisez ce qui précède
 et vérifiez l'exemple ci-dessous. Vous pouvez également regarder le code
-[source](https://github.com/mozilla/nunjucks/blob/master/src/parser.js).
+[source](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/parser.js).
 
 L'utilisation la plus courante consiste à traiter à l'exécution le contenu
 de certains tags. C'est comme les filtres, mais sous stéroïdes car vous ne vous

--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -1793,7 +1793,7 @@ Compte et rend le nombre de mot à l'intérieur d'une chaine :
 ```
 
 Sinon, il est facile de lire le [code
-JavaScript](https://github.com/mozilla/nunjucks/blob/master/src/filters.js)
+JavaScript](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/filters.js)
 qui implémente ces filtres.
 
 {% endraw %}

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1832,7 +1832,7 @@ Count and output the number of words in a string:
 ```
 
 Alternatively, it's easy to [read the JavaScript
-code](https://github.com/mozilla/nunjucks/blob/master/src/filters.js)
+code](https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/filters.js)
 that implements these filters.
 
 {% endraw %}


### PR DESCRIPTION
## Summary

Proposed change: Fix broken links in docs.


Update the links used in `docs/api` and `docs/templating` (and translated versions) to point at `https://github.com/mozilla/nunjucks/blob/master/nunjucks/src/` instead of the incorrect `https://github.com/mozilla/nunjucks/blob/master/src/`

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* ~~[ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.~~
* ~~[ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).~~

<!-- Tick of items by replacing `[ ]` by `[x]` -->