### PR TITLE
Fixing "Invalid type: Is" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 =========
 
 * Add `forceescape` filter. Fixes [#782](https://github.com/mozilla/nunjucks/issues/782)
+* Fix "Invalid type: Is" error for `{% if value is defined %}. Fixes
+  [#1110](https://github.com/mozilla/nunjucks/issues/1110)
 
 3.1.2 (Feb 23 2018)
 -------------------

--- a/nunjucks/src/compiler.js
+++ b/nunjucks/src/compiler.js
@@ -166,6 +166,7 @@ class Compiler extends Obj {
       nodes.Compare,
       nodes.InlineIf,
       nodes.In,
+      nodes.Is,
       nodes.And,
       nodes.Or,
       nodes.Not,

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -39,6 +39,28 @@
       })).to.be('false');
     });
 
+    it('should support "is defined" in {% if %} expressions', function() {
+      expect(
+        render('{% if foo is defined %}defined{% else %}undefined{% endif %}',
+          {})
+      ).to.be('undefined');
+      expect(
+        render('{% if foo is defined %}defined{% else %}undefined{% endif %}',
+          {foo: null})
+      ).to.be('defined');
+    });
+
+    it('should support "is not defined" in {% if %} expressions', function() {
+      expect(
+        render('{% if foo is not defined %}undefined{% else %}defined{% endif %}',
+          {})
+      ).to.be('undefined');
+      expect(
+        render('{% if foo is not defined %}undefined{% else %}defined{% endif %}',
+          {foo: null})
+      ).to.be('defined');
+    });
+
     it('undefined should detect undefinedness', function() {
       expect(render('{{ foo is undefined }}')).to.be('true');
       expect(render('{{ foo is not undefined }}')).to.be('false');


### PR DESCRIPTION
## Summary

Proposed change:

Fixing "Template render error: assertType: invalid type: Is" error.

`is defined` support was added in https://github.com/mozilla/nunjucks/pull/1033

Closes #1110 .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->