### PR TITLE
Escape unicode newlines when compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* Fix "Unexpected token" error for U+2028 unicode newline. Fixes [#126](https://github.com/mozilla/nunjucks/issues/126) and [#736](https://github.com/mozilla/nunjucks/issues/736)
+
 3.1.3 (May 19 2018)
 -------------------
 

--- a/nunjucks/src/compiler.js
+++ b/nunjucks/src/compiler.js
@@ -278,6 +278,7 @@ class Compiler extends Obj {
       val = val.replace(/\n/g, '\\n');
       val = val.replace(/\r/g, '\\r');
       val = val.replace(/\t/g, '\\t');
+      val = val.replace(/\u2028/g, '\\u2028');
       this._emit(`"${val}"`);
     } else if (node.value === null) {
       this._emit('null');

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -55,6 +55,11 @@
       finish(done);
     });
 
+    it('should escape Unicode line seperators', function(done) {
+      equal('\u2028', '\u2028');
+      finish(done);
+    });
+
     it('should compile references', function(done) {
       equal('{{ foo.bar }}',
         {


### PR DESCRIPTION
## Summary

Proposed change:

Escapes the `\u2028` unicode newline character to avoid errors when compiling.

Closes #126, closes #736 .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).