### PR TITLE
Update yargs to 12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "a-sync-waterfall": "^1.0.0",
     "asap": "^2.0.3",
     "postinstall-build": "^5.0.1",
-    "yargs": "^3.32.0"
+    "yargs": "^12.0.1"
   },
   "browser": "./browser/nunjucks.js",
   "devDependencies": {


### PR DESCRIPTION
## Summary

This changeset updates yargs to 12.0.1, the reason behind it is because there are licensing problems with some transitive dependencies of yargs, for example `invert-kv`, `lcid` tree doesn't contain license files and thus makes it a breach of the license to have a local copy from NPM since NPM package did not contain the license and copyright notice which the license text states must be present to follow the license.

For example, invert-kv is MIT licensed and the MIT license states:

> ... subject to the following conditions:
>
> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

Resolved in https://github.com/sindresorhus/lcid/issues/3 (and https://github.com/yargs/yargs/pull/1195). There isn't a release of yargs with the bump yet however it did land in master. I would expect there will be a patch or similiar release of yargs bumping the transative dependencies. Since that would be compatible with the version range I have specificed that would instantly work. I would like to get this change out sooner updating the yargs dependency to 12 so that it would make it into sooner releases of nunjucks to solve down downstream licensing problems I am facing while trying to use nunjucks (which transitively depends on packages which do not have valid licenses).

```
└─┬ yargs@3.32.0
  ├── camelcase@2.1.1
  ├─┬ cliui@3.2.0
  │ ├── string-width@1.0.2 deduped
  │ ├─┬ strip-ansi@3.0.1
  │ │ └── ansi-regex@2.1.1
  │ └─┬ wrap-ansi@2.1.0
  │   ├── string-width@1.0.2 deduped
  │   └── strip-ansi@3.0.1 deduped
  ├── decamelize@1.2.0
  ├─┬ os-locale@1.4.0
  │ └─┬ lcid@1.0.0
  │   └── invert-kv@1.0.0
  ├─┬ string-width@1.0.2
  │ ├── code-point-at@1.1.0
  │ ├─┬ is-fullwidth-code-point@1.0.0
  │ │ └── number-is-nan@1.0.1
  │ └── strip-ansi@3.0.1 deduped
  ├── window-size@0.1.4
  └── y18n@3.2.1
```

I have looked through the APIs of yargs that are used within `bin/precompile` and they all seem to be supported in yargs 12.0, I am also making an assumption that the behaviour is properly tested, if it is not then this would warrant further scrutiny incase it breaks any behaviours of the nunjucks. This does update yargs version by 9 major versions.

## Checklist

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).