### PR TITLE
Use spacing consistent with other filter usage in templating doc

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -908,7 +908,7 @@ Return the absolute value of the argument:
 **Input**
 
 ```jinja
-{{ -3|abs }}
+{{ -3 | abs }}
 ```
 
 **Output**


### PR DESCRIPTION
## Summary

Proposed change:

* Update spacing in `abs` filter example to be consistent with the other filter usage for style purposes

Closes none.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.

<!-- Tick of items by replacing `[ ]` by `[x]` -->