### PR TITLE
Fix dependency version for node v11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-register": "@babel/register"
   },
   "engines": {
-    "node": ">= 6.9.0 <= 11.0.0-0"
+    "node": ">= 6.9.0 <= 11.0.0"
   },
   "scripts": {
     "build:transpile": "babel nunjucks --out-dir .",


### PR DESCRIPTION
## Summary

When upgrading to node v11.0.0, I get this error when re-install nunjucks.

```
Expected version ">= 6.9.0 <= 11.0.0-0". Got "11.0.0"
```

Proposed change:

Fix the semvar version number in package.json.

Closes #1160 .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).