### PR TITLE
Fix engine version for Node v11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* Fix engine version for Node v11.1.0
 * Fix "Unexpected token" error for U+2028 unicode newline. Fixes [#126](https://github.com/mozilla/nunjucks/issues/126) and [#736](https://github.com/mozilla/nunjucks/issues/736)
 
 3.1.3 (May 19 2018)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-register": "@babel/register"
   },
   "engines": {
-    "node": ">= 6.9.0 <= 11.0.0"
+    "node": ">= 6.9.0 <= 11.1.0"
   },
   "scripts": {
     "build:transpile": "babel nunjucks --out-dir .",


### PR DESCRIPTION
## Summary

This library can not be used with Node version > 11.0.0-0 today. This change makes it possible to use it with <= 11.1.0.

Could this be part of a release soon? We cannot use it as we are on v11.1 of node.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).