### PR TITLE
Fix engine dependency version for Node versions > 11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+* Fix engine dependency version for Node versions > 11.1.0;
+  now there is only a minimum Node dependency and not a maximum dependency;
+  the engine dependency is now a blacklist rather than a whitelist;
+  it indicates Node versions that are known NOT to work, and unknown future
+  versions are accepted by default rather than rejected by default.
+  This fixes a systematic problem where Nunjucks and all of its downstream
+  dependencies break every time a new Node version is released, despite the
+  Node update being backwards compatible, thus forcing a new Nunjucks
+  release such as 3.1.4 until the goalpost is soon moved again.
+  Fixes [#1168](https://github.com/mozilla/nunjucks/issues/1168).
+
 3.1.4 (Nov 9 2018)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-register": "@babel/register"
   },
   "engines": {
-    "node": ">= 6.9.0 <= 11.1.0"
+    "node": ">= 6.9.0"
   },
   "scripts": {
     "build:transpile": "babel nunjucks --out-dir .",


### PR DESCRIPTION
## Summary

Proposed change:

Fix engine dependency version for Node versions > 11.1.0;
now there is only a minimum Node dependency and not a maximum dependency;
the engine dependency is now a blacklist rather than a whitelist;
it indicates Node versions that are known NOT to work, and unknown future
versions are accepted by default rather than rejected by default.

This fixes a systematic problem where Nunjucks and all of its downstream
dependencies break every time a new Node version is released, despite the
Node update being backwards compatible, thus forcing a new Nunjucks
release such as 3.1.4 until the goalpost is soon moved again.

Closes #1168 .

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [X] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [X] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).
