### PR TITLE
Removed postinstall-build in favor of npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "a-sync-waterfall": "^1.0.0",
     "asap": "^2.0.3",
-    "postinstall-build": "^5.0.1",
     "yargs": "^3.32.0"
   },
   "browser": "./browser/nunjucks.js",
@@ -72,7 +71,7 @@
     "codecov": "codecov",
     "mocha": "mocha -R spec tests",
     "lint": "eslint nunjucks scripts tests",
-    "postinstall": "node postinstall-build.js src",
+    "prepare": "npm run build",
     "test:instrument": "cross-env NODE_ENV=test scripts/bundle.js",
     "test:runner": "cross-env NODE_ENV=test scripts/testrunner.js",
     "test": "npm run lint && npm run test:instrument && npm run test:runner"

--- a/postinstall-build.js
+++ b/postinstall-build.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-require('postinstall-build/index')();
-


### PR DESCRIPTION
## Summary

Proposed change:

[postinstall-build is now deprecated](https://github.com/exogen/postinstall-build) because of [npm@4 `prepare` lifecycle script](https://docs.npmjs.com/misc/scripts).

This will break for people using nunjucks as a git dependency with npm < 4. As node 6 end-of-life is coming close, less people will be using npm@3.x. This will help with the third Purpose item:

> * Works in all node releases that are
  [actively maintained by the Node Foundation](https://github.com/nodejs/Release#release-schedule)

Also, npm@5 is the actual LTS version, so npm@3 and npm@4 should be considered deprecated.

Closes #1167.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->