### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -254,7 +254,7 @@ The [`dictsort`](http://jinja.pocoo.org/docs/templates/#dictsort) filter is
 available for sorting objects when iterating over them.
 
 ES iterators are supported, like the new builtin Map and Set. But also
-anything implementing the iterator protocal.
+anything implementing the iterable protocol.
 
 ```js
 var fruits = new Map([


### PR DESCRIPTION
## Summary

Fix minor typo in templating.md. "iterator protocal" > "iterable protocol"

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).
