### PR TITLE
Update faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,6 @@ Additionally, there are few jinja2 features not implemented in nunjucks:
 * The special `self` variable
 * `for` does not support `if not` and `else`
 * `if i is divisibleby(3)`-style conditionals
-* Named block end tags: `{% endblock content %}`
 * Sandboxed mode
   * Note: this makes it **unsuitable for applications requiring [user-defined templates](api.html#user-defined-templates-warning)**
 * Line statements: `# for item in seq`


### PR DESCRIPTION
Named block end tags _are_ supported in Nunjucks. Added in [v2.4.0](
https://github.com/mozilla/nunjucks/releases/tag/v2.4.0)

## Summary

Proposed change: Remove bullet from FAQ stating that named end block tags aren't supported.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).