### PR TITLE
Display syntax plugins in a table for human readability

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -38,12 +38,22 @@ include recognition of the `.njk` extension.
 
 Plugins are available in various editors to support the `jinja` syntax highlighting of Nunjucks.
 
-* atom <https://github.com/alohaas/language-nunjucks>
-* vim <https://github.com/niftylettuce/vim-jinja>
-* brackets <https://github.com/axelboc/nunjucks-brackets>
-* sublime <https://github.com/mogga/sublime-nunjucks/blob/master/Nunjucks.tmLanguage>
-* emacs <http://web-mode.org>
-* vscode <https://github.com/ronnidc/vscode-nunjucks>
+| Editor       | Plugins                                        |
+|--------------|------------------------------------------------|
+| Atom         | [language-nunjucks][atom-1]                    |
+| Vim          | [Vim-Jinja2-Syntax][vim-1], [vim-jinja][vim-2] |
+| Brackets     | [nunjucks-brackets][bracket-1]                 |
+| Sublime Text | [sublime-nunjucks][sublime-1]                  |
+| Emacs        | [web-mode.el][emacs-1]                         |
+| VS Code      | [vscode-nunjucks][vscode-1]                    |
+
+[atom-1]:https://github.com/alohaas/language-nunjucks
+[vim-1]:https://github.com/Glench/Vim-Jinja2-Syntax
+[vim-2]:https://github.com/niftylettuce/vim-jinja
+[bracket-1]:https://github.com/axelboc/nunjucks-brackets
+[sublime-1]:https://github.com/mogga/sublime-nunjucks
+[emacs-1]:http://web-mode.org/
+[vscode-1]:https://github.com/ronnidc/vscode-nunjucks
 
 ## Variables
 


### PR DESCRIPTION
## Summary

The "Syntax Highlighting" section was very helpful as I started using Nunjucks.

I made the following changes to make it more human readable.

* Change from list to table format.
* Rename editor to correct name.
* Add "Vim-Jinja2-Syntax" as the first choice in the Vim editor.
  * Have more users.
  * Actively changed by more maintainers.

With this fix, the "Syntax Highlighting" section is drawn as follows:
![plugins-in-a-table](https://user-images.githubusercontent.com/221802/56090096-3b28fe80-5ed8-11e9-9327-9f2ca82ee594.png)


## Checklist

This P-R is only a correction of the document. 

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

## Question

I tried to confirm this correction result with Jekyll.

I made an environment referring to the discussion of #797, but an error occurs.

```sh
$ make
jekyll serve --watch
Configuration file: /home/raimon49/works/git/nunjucks/docs/_config.yml
            Source: /home/raimon49/works/git/nunjucks/docs
       Destination: /home/raimon49/works/git/nunjucks/docs/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
  Liquid Exception: undefined method `map' for nil:NilClass in cn/api.md
jekyll 3.8.5 | Error:  undefined method `map' for nil:NilClass
```

Do I need to include a specific version of a gem to generate?

My environment is as follows. I have installed `jekyll`, `redcarpet` and `pygments.rb`.

```sh
$ gem list

*** LOCAL GEMS ***

addressable (2.6.0)
bigdecimal (default: 1.4.1)
bundler (default: 1.17.2)
cmath (default: 1.0.0)
colorator (1.1.0)
concurrent-ruby (1.1.5)
csv (default: 3.0.4)
date (default: 2.0.0)
did_you_mean (1.3.0)
e2mmap (default: 0.1.0)
em-websocket (0.5.1)
etc (default: 1.0.1)
eventmachine (1.2.7)
fcntl (default: 1.0.0)
ffi (1.10.0)
fiddle (default: 1.0.0)
fileutils (default: 1.1.0)
forwardable (default: 1.2.0)
forwardable-extended (2.6.0)
http_parser.rb (0.6.0)
i18n (0.9.5)
io-console (default: 0.4.7)
ipaddr (default: 1.2.2)
irb (default: 1.0.0)
jekyll (3.8.5)
jekyll-sass-converter (1.5.2)
jekyll-watch (2.2.1)
json (default: 2.1.0)
kramdown (1.17.0)
liquid (4.0.3)
listen (3.1.5)
logger (default: 1.3.0)
matrix (default: 0.1.0)
mercenary (0.3.6)
minitest (5.11.3)
multi_json (1.13.1)
mutex_m (default: 0.1.0)
net-telnet (0.2.0)
openssl (default: 2.1.2)
ostruct (default: 0.1.0)
pathutil (0.16.2)
power_assert (1.1.3)
prime (default: 0.1.0)
psych (default: 3.1.0)
public_suffix (3.0.3)
pygments.rb (1.2.1)
rake (12.3.2)
rb-fsevent (0.10.3)
rb-inotify (0.10.0)
rdoc (default: 6.1.0)
redcarpet (3.4.0)
rexml (default: 3.1.9)
rouge (3.3.0)
rss (default: 0.2.7)
ruby_dep (1.5.0)
safe_yaml (1.0.5)
sass (3.7.4)
sass-listen (4.0.0)
scanf (default: 1.0.0)
sdbm (default: 1.0.0)
shell (default: 0.7)
stringio (default: 0.0.2)
strscan (default: 1.0.0)
sync (default: 0.5.0)
test-unit (3.2.9)
thwait (default: 0.1.0)
tracer (default: 0.1.0)
webrick (default: 1.4.2)
xmlrpc (0.3.0)
zlib (default: 1.0.0)
```