### PR TITLE
Document `with context` behavior for `import` directive

### DIFF
--- a/docs/fr/templating.md
+++ b/docs/fr/templating.md
@@ -513,8 +513,8 @@ du template inclus, et les résultats de ce rendu sont inclus.
 exportées. Les macros et les affectations de haut niveau (faites avec [`set`](#set)) sont exportées
 depuis les templates, ceci vous permet donc d'y accéder dans un template différent.
 
-Les templates importés sont traités sans le contexte actuel, ils n'ont pas
-accès à toutes les variables du template actuel.
+Les templates importés sont traités sans le contexte actuel par défaut, ils
+n'ont pas accès à toutes les variables du template actuel.
 
 Commençons par un template appelé `forms.html` qui contient ce qui suit :
 
@@ -555,6 +555,13 @@ actuel avec `from import` :
 {{ field('user') }}
 {{ description('Password') }}
 {{ field('pass', type='password') }}
+```
+
+Si vous ajoutez `with context` à la balise `import`, le template importé
+sera traité avec le contexte actuel.
+
+```jinja
+{% from "forms.html" import field with context %}
 ```
 
 `import` accepte n'importe quelle expression arbitraire, donc vous pouvez y passer

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -544,8 +544,8 @@ render of the included template, and the results of that render are included.
 values. Macros and top-level assignments (done with [`set`](#set)) are exported
 from templates, allowing you to access them in a different template.
 
-Imported templates are processed without the current context, so they do not
-have access to any of the current template variables.
+Imported templates are processed without the current context by default, so
+they do not have access to any of the current template variables.
 
 Let's start with a template called `forms.html` that has the following in it:
 
@@ -586,6 +586,13 @@ with `from import`:
 {{ field('user') }}
 {{ description('Password') }}
 {{ field('pass', type='password') }}
+```
+
+By adding `with context` to the end of an `import` directive, the imported
+template is processed with the current context.
+
+```jinja
+{% from "forms.html" import field with context %}
 ```
 
 `import` actually accepts any arbitrary expression, so you can pass anything


### PR DESCRIPTION
## Summary

Proposed change:

* Document `with context` behavior on an `import` directive.

For example:

in a.nunj:
```jinja
{% set processed_var = from_context %}
```

in b.nunj:
```jinja
{% set from_context = "hello" %}
{% from "./a.nunj" import processed_var with context %}
{{ processed_var }} {# will output "hello" #}
```

in c.nunj:
```jinja
{% set from_context = "hello" %}
{% from "./a.nunj" import processed_var %}
{{ processed_var }} {# will not output anything #}
```

Closes #522.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.

<!-- Tick of items by replacing `[ ]` by `[x]` -->