### PR TITLE
Never call callbacks with undefined values

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,9 +33,11 @@ nunjucks.render(name, [context], [callback])
 
 Renders the template named **name** with the **context** hash. If
 **callback** is provided, it will be called when done with any
-possible error as the first argument and the result as the second.
-Otherwise, the result is returned from `render` and errors are thrown.
-See [asynchronous support](#asynchronous-support) for more info.
+possible error as the first argument (or `null` if there were no
+errors) and the result as the second (or `null` if there were
+errors). Otherwise, the result is returned from `render` and errors
+are thrown. See [asynchronous support](#asynchronous-support) for
+more info.
 
 See the warning about **not allowing [users to define their own
 templates](#user-defined-templates-warning).**
@@ -313,11 +315,13 @@ getTemplate
 env.getTemplate(name, [eagerCompile], [callback])
 
 Retrieve the template named **name**. If **eagerCompile** is `true`,
-compile it now instead of on render. If **callback** is supplied, call
-it with any errors and a template (if found), otherwise return
-synchronously. If using any async loaders, you must use the async API.
-The builtin loaders do not require this. See
-[asynchronous support](#asynchronous-support) and [loaders](#loader).
+compile it now instead of on render. If **callback** is supplied,
+call it with an errors as the first argument (if any errors are
+present) or `null` otherwise, and a template as the second argument,
+or `null` if no template is found; otherwise, return synchronously.
+If using any async loaders, you must use the async API. The builtin
+loaders do not require this. See [asynchronous
+support](#asynchronous-support) and [loaders](#loader).
 
 ```js
 var tmpl = env.getTemplate('page.html');
@@ -417,6 +421,27 @@ result (see [asynchronous support](#asynchronous-support)), otherwise
 return the rendered string.
 
 {% endapi %}
+
+{% api %}
+TemplateError
+nunjucks.TemplateError(err, lineno, colno)
+
+An error raised during template rendering. `err` can be an `Error`
+instance, in which case it is used as the new `TemplateError`'s
+source, or a string, in which case it is a message used to describe
+the error.
+
+In addition to the standard `Error` string properties `name`,
+`message`, and `stack`, `TemplateError` instances will have the
+following properties:
+
+* **lineno** and **colno**, integers indicating where the error was
+  created.
+* **value**, the `Error` which caused the `TemplateError`, or
+  `undefined` if no source error was given.
+
+{% endapi %}
+
 {% raw %}
 
 ## Loader

--- a/nunjucks/index.js
+++ b/nunjucks/index.js
@@ -57,6 +57,7 @@ module.exports = {
   lexer: lexer,
   runtime: runtime,
   lib: lib,
+  TemplateError: lib.TemplateError,
   nodes: nodes,
   installJinjaCompat: installJinjaCompat,
   configure: configure,

--- a/nunjucks/src/environment.js
+++ b/nunjucks/src/environment.js
@@ -242,7 +242,7 @@ class Environment extends EmitterObj {
 
       if (err) {
         if (cb) {
-          cb(err);
+          cb(err, null);
           return;
         } else {
           throw err;
@@ -523,7 +523,7 @@ class Template extends Obj {
       this.compile();
     } catch (e) {
       if (cb) {
-        return cb(e);
+        return cb(e, null);
       } else {
         throw e;
       }

--- a/nunjucks/src/web-loaders.js
+++ b/nunjucks/src/web-loaders.js
@@ -33,7 +33,7 @@ class WebLoader extends Loader {
     this.fetch(this.baseURL + '/' + name, (err, src) => {
       if (err) {
         if (cb) {
-          cb(err.content);
+          cb(err.content, null);
         } else if (err.status === 404) {
           result = null;
         } else {
@@ -76,7 +76,7 @@ class WebLoader extends Loader {
           cb({
             status: ajax.status,
             content: ajax.responseText
-          });
+          }, null);
         }
       }
     };

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -65,7 +65,7 @@
       env = new Environment(new MyLoader(templatesPath));
       env.getTemplate('fake.njk', function(err, parent) {
         expect(err).to.be.a(Error);
-        expect(parent).to.be(undefined);
+        expect(parent).to.be(null);
 
         done();
       });


### PR DESCRIPTION
# Summary

We use 'null' to indicate an absence of a value in callbacks, so be consistent. Leaving parameters out makes them 'undefined', not 'null'. Always use a second parameter of 'null' rather than leaving it out.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature). **N/A**