### PR TITLE
Throw existing render error instead of null

### DIFF
--- a/nunjucks/src/environment.js
+++ b/nunjucks/src/environment.js
@@ -473,20 +473,20 @@ class Template extends Obj {
     const frame = parentFrame ? parentFrame.push(true) : new Frame();
     frame.topLevel = true;
     let syncResult = null;
-    let didError = false;
+    let existingError = false;
 
     this.rootRenderFunc(this.env, context, frame, globalRuntime, (err, res) => {
-      if (didError) {
+      if (existingError) {
         // prevent multiple calls to cb
         if (cb) {
           return;
         } else {
-          throw err;
+          throw err || existingError;
         }
       }
       if (err) {
         err = lib._prettifyError(this.path, this.env.opts.dev, err);
-        didError = true;
+        existingError = err;
       }
 
       if (cb) {


### PR DESCRIPTION
## Summary

If there is an existing render error a flag is set so `cb()` isn't called twice, but when there is no `cb()` it tries to throw a new err, that might not exist and will therefore be null. This causes a `lineno of null` type error instead of seeing the render error message.

Proposed change:

Save off the previous error instead of just a boolean flag as to if an error occurred and throw that error.

Closes #1245 .

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->