### PR TITLE
Prevent optional dependency Chokidar from loading when not watching

### DIFF
--- a/nunjucks/src/node-loaders.js
+++ b/nunjucks/src/node-loaders.js
@@ -7,9 +7,6 @@ const path = require('path');
 const Loader = require('./loader');
 const {PrecompiledLoader} = require('./precompiled-loader.js');
 let chokidar;
-try {
-  chokidar = require('chokidar'); // eslint-disable-line global-require
-} catch (e) {} // eslint-disable-line no-empty
 
 class FileSystemLoader extends Loader {
   constructor(searchPaths, opts) {
@@ -37,7 +34,9 @@ class FileSystemLoader extends Loader {
     if (opts.watch) {
       // Watch all the templates in the paths and fire an event when
       // they change
-      if (!chokidar) {
+      try {
+        chokidar = require('chokidar'); // eslint-disable-line global-require
+      } catch (e) {
         throw new Error('watch requires chokidar to be installed');
       }
       const paths = this.searchPaths.filter(fs.existsSync);
@@ -94,7 +93,9 @@ class NodeResolveLoader extends Loader {
     this.noCache = !!opts.noCache;
 
     if (opts.watch) {
-      if (!chokidar) {
+      try {
+        chokidar = require('chokidar'); // eslint-disable-line global-require
+      } catch (e) {
         throw new Error('watch requires chokidar to be installed');
       }
       this.watcher = chokidar.watch();


### PR DESCRIPTION
## Summary

Proposed change:

Since Chokidar is an optional dependency, and relatively heavy, it would be best to defer requiring it until the watcher is actually needed. This gives a slight speed increase when using FileSystemResolver or NodeResolver with the watch option set to false, unless the end-user has already loaded Chokidar.

Triggering require() twice when using both loaders does not have a big performance impact because of the module cache. This is an internal change only. I have not written tests, since these would depend upon module.cache[] side-effects to run.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->