### PR TITLE
Replace yargs with commander to reduce dependencies

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -1,70 +1,52 @@
 #!/usr/bin/env node
-var path = require('path');
+var commander = require('commander');
 var precompile = require('../src/precompile').precompile;
 var Environment = require('../src/environment').Environment;
 var lib = require('../src/lib');
 
-var yargs = require('yargs')
+var cmdpath = null;
 
-    .usage('$0 [-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-w|--wrapper <wrapper>] <path>')
-    .wrap(80)
+commander
+  .name('precompile')
+  .usage('[-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-w|--wrapper <wrapper>] <path>')
+  .arguments('<path>')
+  .helpOption('-?, -h, --help', 'Display this help message')
+  .option('-f, --force', 'Force compilation to continue on error')
+  .option('-a, --filters <filters>', 'Give the compiler a comma-delimited list of asynchronous filters, required for correctly generating code')
+  .option('-n, --name <name>', 'Specify the template name when compiling a single file')
+  .option('-i, --include <regex>', 'Include a file or folder which match the regex but would otherwise be excluded. You can use this flag multiple times', concat, ['\\.html$', '\\.jinja$'])
+  .option('-x, --exclude <regex>', 'Exclude a file or folder which match the regex but would otherwise be included. You can use this flag multiple times', concat, [])
+  .option('-w, --wrapper <wrapper>', 'Load a external plugin to change the output format of the precompiled templates (for example, "-w custom" will load a module named "nunjucks-custom")')
+  .action(function (path) {
+    cmdpath = path;
+  })
+  .parse(process.argv);
 
-    .describe('help', 'Display this help message')
-        .boolean('help')
-        .alias('h', 'help')
-        .alias('?', 'help')
+function concat(value, previous) {
+  return previous.concat(value);
+}
 
-    .describe('force', 'Force compilation to continue on error')
-        .boolean('force')
-        .alias('f', 'force')
-
-    .describe('filters', 'Give the compiler a comma-delimited list of asynchronous filters, required for correctly generating code')
-        .string('filters')
-        .alias('a', 'filters')
-
-    .describe('name', 'Specify the template name when compiling a single file')
-        .string('name')
-        .alias('n', 'n')
-
-    .describe('include', 'Include a file or folder which match the regex but would otherwise be excluded. You can use this flag multiple times')
-        .string('include' )
-        .default('include', ['\\.html$', '\\.jinja$'])
-        .alias('i', 'include')
-
-    .describe('exclude', 'Exclude a file or folder which match the regex but would otherwise be included. You can use this flag multiple times')
-        .string('exclude' )
-        .default('exclude', [])
-        .alias('x', 'exclude')
-
-    .describe('wrapper', 'Load a external plugin to change the output format of the precompiled templates (for example, "-w custom" will load a module named "nunjucks-custom")')
-        .string('wrapper')
-        .alias('w', 'wrapper')
-
-    .demand(1);
-
-var argv = yargs.argv;
-
-if (argv.help) {
-    yargs.showHelp();
-    process.exit(1);
+if (cmdpath == null) {
+  commander.outputHelp();
+  console.error('\nerror: no path given');
+  process.exit(1);
 }
 
 var env = new Environment([]);
 
-lib.each([].concat(argv.filters).join(',').split(','), function(name) {
-    env.addFilter(name.trim(), function() {}, true);
+lib.each([].concat(commander.filters).join(',').split(','), function (name) {
+  env.addFilter(name.trim(), function () {}, true);
 });
 
-if(argv.wrapper) {
-    argv.wrapper = require('nunjucks-' + argv.wrapper).wrapper;
+if (commander.wrapper) {
+  commander.wrapper = require('nunjucks-' + commander.wrapper).wrapper;
 }
 
-console.log(precompile(argv._[0], {
-    env : env,
-    force : argv.force,
-    name : argv.name,
-    wrapper: argv.wrapper,
-
-    include : [].concat(argv.include),
-    exclude : [].concat(argv.exclude)
+console.log(precompile(cmdpath, {
+  env : env,
+  force : commander.force,
+  name : commander.name,
+  wrapper: commander.wrapper,
+  include : [].concat(commander.include),
+  exclude : [].concat(commander.exclude)
 }));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "a-sync-waterfall": "^1.0.0",
     "asap": "^2.0.3",
-    "yargs": "^3.32.0"
+    "commander": "^3.0.2"
   },
   "browser": "./browser/nunjucks.js",
   "devDependencies": {


### PR DESCRIPTION
## Summary

Replace [`yargs`](https://www.npmjs.com/package/yargs) with [`commander`](https://www.npmjs.com/package/commander), which is only used in `bin/precompile`. This PR does not break command interface, because they have the same logic and options.

Both yargs and commander can implement the same options for `bin/compile`, but [commander pulls in **0 dependency**](https://www.npmjs.com/package/commander?activeTab=dependencies) while [yargs pulls in **11 dependencies directly and maybe many others indirectly**](https://www.npmjs.com/package/yargs?activeTab=dependencies).

It seems most users of nunjucks use it as an library, not a cli-program, and they may not like many dependencies pulled in by yargs in their projects (like me).

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [X] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [X] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [X] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [X] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).