### PR TITLE
Chokidar bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack": "^3.10.0"
   },
   "optionalDependencies": {
-    "chokidar": "^2.0.0"
+    "chokidar": "^3.3.0"
   },
   "_moduleAliases": {
     "babel-register": "@babel/register"


### PR DESCRIPTION
## Summary

Proposed change:

Update optional dependency `chokidar` from `^2.0.0` to `^3.3.0`.

This fixes the warning users get when installing:
```
warning nunjucks > chokidar > fsevents@1.2.9: One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size
```

There are also performance improvements, and `fsevents` no longer has to be built at install. For more information, see: https://paulmillr.com/posts/chokidar-3-save-32tb-of-traffic/

The API of v3 is the same as v2, except that dotfiles are no longer ignored by default. I don't think this is relevant for nunjucks. The minimum node version is bumped from v6 to v8, but i'm not sure if that matters considering v6 is no longer in maintenance.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->