### PR TITLE
Add support for nested attributes in `groupBy` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog
   [ogonkov](https://github.com/ogonkovv)!
 * Fix precompile binary script `TypeError: name.replace is not a function`.
   Fixes [#1295](https://github.com/mozilla/nunjucks/issues/1295).
+* Add support for nested attributes on
+  [`groupby` filter](https://mozilla.github.io/nunjucks/templating.html#groupby);
+  respect `throwOnUndefined` option, if the groupby attribute is undefined.
+  Merge of [#1276](https://github.com/mozilla/nunjucks/pull/1276); fixes
+  [#1198](https://github.com/mozilla/nunjucks/issues/1198). Thanks
+  [ogonkov](https://github.com/ogonkovv)!
 
 3.2.1 (Mar 17 2020)
 -------------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1160,6 +1160,48 @@ green : james jessie
 blue : john jim
 ```
 
+Attribute can use dot notation to use nested attribute, like `date.year`.
+
+**Input**
+
+```jinja
+{% set posts = [
+      {
+        date: {
+          year: 2019
+        },
+        title: 'Post 1'
+      },
+      {
+        date: {
+          year: 2018
+        },
+        title: 'Post 2'
+      },
+      {
+        date: {
+          year: 2019
+        },
+        title: 'Post 3'
+      }
+    ]
+%}
+
+{% for year, posts in posts | groupby("date.year") %}
+    :{{ year }}:
+    {% for post in posts %}
+        {{ post.title }}
+    {% endfor %}
+{% endfor %}
+```
+
+**Output**
+:2018:
+Post 2
+:2019:
+Post 1
+Post 3
+
 ### indent
 
 Indent a string using spaces.

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -164,7 +164,7 @@ function forceescape(str) {
 exports.forceescape = forceescape;
 
 function groupby(arr, attr) {
-  return lib.groupBy(arr, attr);
+  return lib.groupBy(arr, attr, this.env.opts.throwOnUndefined);
 }
 
 exports.groupby = groupby;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -248,6 +248,34 @@
     });
 
     it('groupby', function(done) {
+      const namesContext = {
+        items: [{
+          name: 'james',
+          type: 'green'
+        },
+        {
+          name: 'john',
+          type: 'blue'
+        },
+        {
+          name: 'jim',
+          type: 'blue'
+        },
+        {
+          name: 'jessie',
+          type: 'green'
+        }]
+      };
+      equal(
+        '{% for type, items in items | groupby("type") %}' +
+        ':{{ type }}:' +
+        '{% for item in items %}' +
+        '{{ item.name }}' +
+        '{% endfor %}' +
+        '{% endfor %}',
+        namesContext,
+        ':green:jamesjessie:blue:johnjim');
+
       equal(
         '{% for type, items in items | groupby("type") %}' +
         ':{{ type }}:' +
@@ -270,10 +298,107 @@
           },
           {
             name: 'jessie',
-            type: 'green'
+            color: 'green'
           }]
         },
-        ':green:jamesjessie:blue:johnjim');
+        ':green:james:blue:johnjim:undefined:jessie');
+
+      equal(
+        '{% for year, posts in posts | groupby("date.year") %}' +
+        ':{{ year }}:' +
+        '{% for post in posts %}' +
+        '{{ post.title }}' +
+        '{% endfor %}' +
+        '{% endfor %}',
+        {
+          posts: [
+            {
+              date: {
+                year: 2019
+              },
+              title: 'Post 1'
+            },
+            {
+              date: {
+                year: 2018
+              },
+              title: 'Post 2'
+            },
+            {
+              date: {
+                year: 2019
+              },
+              title: 'Post 3'
+            }
+          ]
+        },
+        ':2018:Post 2:2019:Post 1Post 3');
+
+      equal(
+        '{% for year, posts in posts | groupby("date.year") %}' +
+        ':{{ year }}:' +
+        '{% for post in posts %}' +
+        '{{ post.title }}' +
+        '{% endfor %}' +
+        '{% endfor %}',
+        {
+          posts: [
+            {
+              date: {
+                year: 2019
+              },
+              title: 'Post 1'
+            },
+            {
+              date: {
+                year: 2018
+              },
+              title: 'Post 2'
+            },
+            {
+              meta: {
+                month: 2
+              },
+              title: 'Post 3'
+            }
+          ]
+        },
+        ':2018:Post 2:2019:Post 1:undefined:Post 3');
+
+      equal(
+        '{% for type, items in items | groupby({}) %}' +
+        ':{{ type }}:' +
+        '{% for item in items %}' +
+        '{{ item.name }}' +
+        '{% endfor %}' +
+        '{% endfor %}',
+        namesContext,
+        ':undefined:jamesjohnjimjessie'
+      );
+
+      const undefinedTemplate = (
+        '{% for type, items in items | groupby("a.b.c") %}' +
+        ':{{ type }}:' +
+        '{% for item in items %}' +
+        '{{ item.name }}' +
+        '{% endfor %}' +
+        '{% endfor %}'
+      );
+      equal(
+        undefinedTemplate,
+        namesContext,
+        ':undefined:jamesjohnjimjessie'
+      );
+
+      expect(function() {
+        render(
+          undefinedTemplate,
+          namesContext,
+          {
+            throwOnUndefined: true
+          }
+        );
+      }).to.throwError(/groupby: attribute "a\.b\.c" resolved to undefined/);
 
       finish(done);
     });


### PR DESCRIPTION
## Summary

Proposed change:

Add support for nested attributes access for `groupBy` filter to match [Jinja2 behaviour](https://jinja.palletsprojects.com/en/2.11.x/templates/#groupby)

Closes #1198 .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->