### PR TITLE
Map tests names to reserved JS names

### DIFF
--- a/nunjucks/src/environment.js
+++ b/nunjucks/src/environment.js
@@ -37,6 +37,21 @@ const noopTmplSrc = {
   }
 };
 
+const testNameMap = {
+  nullTest: 'null',
+  undefinedTest: 'undefined'
+};
+
+/**
+ * Map test names to reserved JS names
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function mapTestName(name) {
+  return name in testNameMap ? testNameMap[name] : name;
+}
+
 class Environment extends EmitterObj {
   init(loaders, opts) {
     // The dev flag determines the trace that'll be shown on errors.
@@ -92,7 +107,10 @@ class Environment extends EmitterObj {
     this.extensionsList = [];
 
     lib._entries(filters).forEach(([name, filter]) => this.addFilter(name, filter));
-    lib._entries(tests).forEach(([name, test]) => this.addTest(name, test));
+    lib._entries(tests).forEach(([name, test]) => this.addTest(
+      mapTestName(name),
+      test
+    ));
   }
 
   _initLoaders() {

--- a/nunjucks/src/tests.js
+++ b/nunjucks/src/tests.js
@@ -179,7 +179,7 @@ function nullTest(value) {
   return value === null;
 }
 
-exports.null = nullTest;
+exports.nullTest = nullTest;
 
 /**
  * Returns true if value is a number.
@@ -235,7 +235,7 @@ function undefinedTest(value) {
   return value === undefined;
 }
 
-exports.undefined = undefinedTest;
+exports.undefinedTest = undefinedTest;
 
 /**
  * Returns `true` if the string is uppercased.


### PR DESCRIPTION
## Summary

Proposed change:
Some tests used names like `null`, and `undefined`. This PR is proposed to map this test to this names in the time of adding to `Environment`.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->