### PR TITLE
Fix `mocha` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express": "4.x",
     "fs-extra": "^5.0.0",
     "get-port": "^3.2.0",
-    "mocha": "*",
+    "mocha": "^7.2.0",
     "mocha-phantomjs-core": "^2.1.2",
     "mocha-phantomjs-istanbul": "0.0.2",
     "module-alias": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express": "4.x",
     "fs-extra": "^5.0.0",
     "get-port": "^3.2.0",
-    "mocha": "^7.2.0",
+    "mocha": "< 8.x",
     "mocha-phantomjs-core": "^2.1.2",
     "mocha-phantomjs-istanbul": "0.0.2",
     "module-alias": "^2.0.3",


### PR DESCRIPTION
## Summary

Proposed change:

Since `mocha` @ 8.x it's not compatible with now deprecated `mocha-phantomjs-core`. As temporary solution this PR is fixing `mocha` version to latest release in 7.x upstream.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->