### PR TITLE
Fix #1295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* Fix bug where precompiling a template from a file failed with a TypeError. [#1295](https://github.com/mozilla/nunjucks/issues/1295)
 * Add [`select` filter](https://mozilla.github.io/nunjucks/templating.html#select).
 
 3.2.1 (Mar 17 2020)

--- a/nunjucks/src/precompile.js
+++ b/nunjucks/src/precompile.js
@@ -73,7 +73,7 @@ function precompile(input, opts) {
   if (pathStats.isFile()) {
     precompiled.push(_precompile(
       fs.readFileSync(input, 'utf-8'),
-      opts.name || input,
+      opts.name() || input,
       env
     ));
   } else if (pathStats.isDirectory()) {


### PR DESCRIPTION
## Summary

Proposed change:

In `precompile` when we're using a file, call `opts.name()` before testing if the result is undefined rather than passing the function pointer downstream. This fixes a bug where `name.replace` was failing because it was being called on a function pointer rather than a string.

Closes #1295 .

Note that an alternative solution to this would be to make `opts.name` a getter; I did not investigate that option because I wanted to make the smallest change that would fix this bug.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change. **No documentation to update; this is a bug fix only**
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change. **It looks like there are already tests, I'm not sure why they don't cover this issue**
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->