### PR TITLE
Add `base` arg to `int` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
 * Add support for nested attributes on
   [`sort` filter](https://mozilla.github.io/nunjucks/templating.html#sort-arr-reverse-casesens-attr);
   respect `throwOnUndefined` if sort attribute is undefined.
+* Add `base` arg to
+  [`int` filter](https://mozilla.github.io/nunjucks/templating.html#int).
 
 3.2.2 (Jul 20 2020)
 -------------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1276,7 +1276,9 @@ Change default indentation to 6 spaces and indent the first line:
 ### int
 
 Convert the value into an integer.
-If the conversion fails 0 is returned.
+If the conversion fails 0 is returned. You can override this default using the
+first parameter. You can also override the default base (10) in the second
+parameter.
 
 **Input**
 

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -632,12 +632,16 @@ function float(val, def) {
 
 exports.float = float;
 
-function int(val, def) {
-  var res = parseInt(val, 10);
-  return (isNaN(res)) ? def : res;
-}
+const intFilter = r.makeMacro(
+  ['value', 'default', 'base'],
+  [],
+  function doInt(value, defaultValue, base = 10) {
+    var res = parseInt(value, base);
+    return (isNaN(res)) ? defaultValue : res;
+  }
+);
 
-exports.int = int;
+exports.int = intFilter;
 
 // Aliases
 exports.d = exports.default;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -237,6 +237,9 @@
     it('int', function() {
       equal('{{ "3.5" | int }}', '3');
       equal('{{ "0" | int }}', '0');
+      equal('{{ "foobar" | int("42") }}', '42');
+      equal('{{ "0x4d32" | int(base=16) }}', '19762');
+      equal('{{ "011" | int(base=8) }}', '9');
     });
 
     it('int (default value)', function() {


### PR DESCRIPTION
## Summary

Proposed change:

Add `base` arg for `int` filter, to match Jinja2 behaviour.

Closes #1307.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->