### PR TITLE
Add `dictsort` filter `reverse` kwarg

### DIFF
--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -83,9 +83,10 @@ function default_(val, def, bool) {
 exports['default'] = default_; // eslint-disable-line dot-notation
 
 const dictsort = r.makeMacro(
-  ['value', 'case_sensitive', 'by'],
+  ['value', 'case_sensitive', 'by', 'reverse'],
   [],
-  function dictsortFilter(val, caseSensitive, by) {
+  // eslint-disable-next-line no-shadow
+  function dictsortFilter(val, caseSensitive, by, reverse) {
     if (!lib.isObject(val)) {
       throw new lib.TemplateError('dictsort filter: val must be an object');
     }
@@ -119,7 +120,9 @@ const dictsort = r.makeMacro(
         }
       }
 
-      return a > b ? 1 : (a === b ? 0 : -1); // eslint-disable-line no-nested-ternary
+      const sortOrder = a > b ? 1 : (a === b ? 0 : -1); // eslint-disable-line no-nested-ternary
+
+      return sortOrder * (reverse === true ? -1 : 1);
     });
 
     return array;

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -82,45 +82,49 @@ function default_(val, def, bool) {
 // TODO: it is confusing to export something called 'default'
 exports['default'] = default_; // eslint-disable-line dot-notation
 
-function dictsort(val, caseSensitive, by) {
-  if (!lib.isObject(val)) {
-    throw new lib.TemplateError('dictsort filter: val must be an object');
-  }
-
-  let array = [];
-  // deliberately include properties from the object's prototype
-  for (let k in val) { // eslint-disable-line guard-for-in, no-restricted-syntax
-    array.push([k, val[k]]);
-  }
-
-  let si;
-  if (by === undefined || by === 'key') {
-    si = 0;
-  } else if (by === 'value') {
-    si = 1;
-  } else {
-    throw new lib.TemplateError(
-      'dictsort filter: You can only sort by either key or value');
-  }
-
-  array.sort((t1, t2) => {
-    var a = t1[si];
-    var b = t2[si];
-
-    if (!caseSensitive) {
-      if (lib.isString(a)) {
-        a = a.toUpperCase();
-      }
-      if (lib.isString(b)) {
-        b = b.toUpperCase();
-      }
+const dictsort = r.makeMacro(
+  ['value', 'case_sensitive', 'by'],
+  [],
+  function dictsortFilter(val, caseSensitive, by) {
+    if (!lib.isObject(val)) {
+      throw new lib.TemplateError('dictsort filter: val must be an object');
     }
 
-    return a > b ? 1 : (a === b ? 0 : -1); // eslint-disable-line no-nested-ternary
-  });
+    let array = [];
+    // deliberately include properties from the object's prototype
+    for (let k in val) { // eslint-disable-line guard-for-in, no-restricted-syntax
+      array.push([k, val[k]]);
+    }
 
-  return array;
-}
+    let si;
+    if (by === undefined || by === 'key') {
+      si = 0;
+    } else if (by === 'value') {
+      si = 1;
+    } else {
+      throw new lib.TemplateError(
+        'dictsort filter: You can only sort by either key or value');
+    }
+
+    array.sort((t1, t2) => {
+      var a = t1[si];
+      var b = t2[si];
+
+      if (!caseSensitive) {
+        if (lib.isString(a)) {
+          a = a.toUpperCase();
+        }
+        if (lib.isString(b)) {
+          b = b.toUpperCase();
+        }
+      }
+
+      return a > b ? 1 : (a === b ? 0 : -1); // eslint-disable-line no-nested-ternary
+    });
+
+    return array;
+  }
+);
 
 exports.dictsort = dictsort;
 


### PR DESCRIPTION
## Summary

Proposed change:

Add `reverse` option for `dictsort` filter.

Closes #1305.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->