### PR TITLE
Add `blank` kwarg for `indent` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
   respect `throwOnUndefined` if sort attribute is undefined.
 * Add `base` arg to
   [`int` filter](https://mozilla.github.io/nunjucks/templating.html#int).
+* Add `blank` option for
+  [`indent` filter](https://mozilla.github.io/nunjucks/templating.html#indent).
 
 3.2.2 (Jul 20 2020)
 -------------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1226,9 +1226,15 @@ Post 3
 
 ### indent
 
+Arguments:
+ * `width`: number of spaces to indent by (`4` by default)
+ * `first`: don't skip indenting the first line (`false` by default)
+ * `blank`: don’t skip indenting empty lines (`true` by default)
+
 Indent a string using spaces.
-Default behaviour is *not* to indent the first line.
-Default indentation is 4 spaces.
+
+For historical reasons `blank` is `true` by default. This is didn't match
+Jinja2 behaviour, and could be changed to `false` in next major version.
 
 **Input**
 

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -170,9 +170,9 @@ function groupby(arr, attr) {
 exports.groupby = groupby;
 
 const indent = r.makeMacro(
-  ['string', 'width', 'first'],
+  ['string', 'width', 'first', 'blank'],
   [],
-  function indent(str, width, indentfirst) {
+  function indent(str, width, indentfirst, blank) {
     str = normalize(str, '');
 
     if (str === '') {
@@ -185,6 +185,10 @@ const indent = r.makeMacro(
     const sp = lib.repeat(' ', width);
 
     const res = lines.map((l, i) => {
+      if (l === '' && blank === false) {
+        return l;
+      }
+
       return (i === 0 && !indentfirst) ? l : `${sp}${l}`;
     }).join('\n');
 

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -169,24 +169,28 @@ function groupby(arr, attr) {
 
 exports.groupby = groupby;
 
-function indent(str, width, indentfirst) {
-  str = normalize(str, '');
+const indent = r.makeMacro(
+  ['string', 'width', 'first'],
+  [],
+  function indent(str, width, indentfirst) {
+    str = normalize(str, '');
 
-  if (str === '') {
-    return '';
+    if (str === '') {
+      return '';
+    }
+
+    width = width || 4;
+    // let res = '';
+    const lines = str.split('\n');
+    const sp = lib.repeat(' ', width);
+
+    const res = lines.map((l, i) => {
+      return (i === 0 && !indentfirst) ? l : `${sp}${l}`;
+    }).join('\n');
+
+    return r.copySafeness(str, res);
   }
-
-  width = width || 4;
-  // let res = '';
-  const lines = str.split('\n');
-  const sp = lib.repeat(' ', width);
-
-  const res = lines.map((l, i) => {
-    return (i === 0 && !indentfirst) ? l : `${sp}${l}`;
-  }).join('\n');
-
-  return r.copySafeness(str, res);
-}
+);
 
 exports.indent = indent;
 

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -430,6 +430,17 @@
       equal('{{ nothing | indent }}', '');
       equal('{{ nothing | indent(2) }}', '');
       equal('{{ nothing | indent(2, true) }}', '');
+
+      equal(
+        '{{ "one\n\ntwo\nthree" | indent(blank=true) }}',
+        'one\n    \n    two\n    three'
+      );
+
+      equal(
+        '{{ "one\n\ntwo\nthree" | indent(blank=false) }}',
+        'one\n\n    two\n    three'
+      );
+
       finish(done);
     });
 


### PR DESCRIPTION
## Summary

Proposed change:

Add `blank` option to `indent` filter to match arguments of Jinja2 filter. Unlike Jinja2 implementation `blank` is `true` by default, to match current default behaviour.

Closes #1306.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->