### PR TITLE
Improve `join` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Unreleased
   respect `throwOnUndefined` if sort attribute is undefined.
 * Add `base` arg to
   [`int` filter](https://mozilla.github.io/nunjucks/templating.html#int).
+* Improve
+  [`join` filter](https://mozilla.github.io/nunjucks/templating.html#join)
+  behaviour: add support for nested attributes; respect `safe` strings in
+  joined values; respect `throwOnUndefined` option, if joined attribute is
+  undefined.
 
 3.2.2 (Jul 20 2020)
 -------------------

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1348,6 +1348,26 @@ This  behaviour is applicable to arrays:
 foo,bar,bear
 ```
 
+To join by nested attribute use dot-notation for `attribute`.
+
+**Input**
+
+```jinja
+{% set items = [
+    { name: {first: 'foo'} },
+    { name: {first: 'bar'} },
+    { name: {first: 'bear'} }]
+%}
+
+{{ items | join(attribute="name.first") }}
+```
+
+**Output**
+
+```jinja
+foobarbear
+```
+
 ### last
 
 Get the last item in an array or the last letter if it's a string:

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -193,9 +193,7 @@ exports.indent = indent;
 const join = r.makeMacro(
   ['value', 'd', 'attribute'],
   [],
-  function joinFilter(arr, del, attr) {
-    del = del || '';
-
+  function joinFilter(arr, del = '', attr) {
     if (attr) {
       const getAttr = lib.getAttrGetter(attr);
       arr = lib.map(arr, getAttr);

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -195,8 +195,19 @@ const join = r.makeMacro(
   [],
   function joinFilter(arr, del = '', attr) {
     if (attr) {
+      const {throwOnUndefined} = this.env.opts;
       const getAttr = lib.getAttrGetter(attr);
-      arr = lib.map(arr, getAttr);
+      arr = lib.map(arr, function toAttribute(item) {
+        const itemAttribute = getAttr(item);
+
+        if (throwOnUndefined === true && itemAttribute === undefined) {
+          throw new TypeError(
+            `join: attribute "${attr}" resolved to undefined`
+          );
+        }
+
+        return itemAttribute;
+      });
     }
 
     if (this.env.opts.autoescape === true) {

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -190,15 +190,19 @@ function indent(str, width, indentfirst) {
 
 exports.indent = indent;
 
-function join(arr, del, attr) {
-  del = del || '';
+const join = r.makeMacro(
+  ['value', 'd', 'attribute'],
+  [],
+  function joinFilter(arr, del, attr) {
+    del = del || '';
 
-  if (attr) {
-    arr = lib.map(arr, (v) => v[attr]);
+    if (attr) {
+      arr = lib.map(arr, (v) => v[attr]);
+    }
+
+    return arr.join(del);
   }
-
-  return arr.join(del);
-}
+);
 
 exports.join = join;
 

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -197,7 +197,8 @@ const join = r.makeMacro(
     del = del || '';
 
     if (attr) {
-      arr = lib.map(arr, (v) => v[attr]);
+      const getAttr = lib.getAttrGetter(attr);
+      arr = lib.map(arr, getAttr);
     }
 
     return arr.join(del);

--- a/nunjucks/src/filters.js
+++ b/nunjucks/src/filters.js
@@ -199,6 +199,12 @@ const join = r.makeMacro(
       arr = lib.map(arr, getAttr);
     }
 
+    if (this.env.opts.autoescape === true) {
+      const result = arr.map(escape).join(escape(del));
+
+      return r.markSafe(result);
+    }
+
     return arr.join(del);
   }
 );

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -487,6 +487,21 @@
         '2019,1996,2030'
       );
 
+      equal(
+        '{{ ["<foo>", "<span>foo</span>"|safe]|join }}',
+        '&lt;foo&gt;<span>foo</span>'
+      );
+
+      equal(
+        '{{ ["<foo>", "<span>foo</span>"|safe]|join("<br>") }}',
+        '&lt;foo&gt;&lt;br&gt;<span>foo</span>'
+      );
+
+      equal(
+        '{{ ["<foo>", "<span>foo</span>"|safe]|join("<br>"|safe) }}',
+        '&lt;foo&gt;<br><span>foo</span>'
+      );
+
       finish(done);
     });
 

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -459,6 +459,34 @@
           }]
         },
         'foo,bar,bear');
+
+      equal(
+        '{{ items | join(",", "meta.date") }}',
+        {
+          items: [
+            {
+              meta: {
+                date: 2019
+              },
+              name: 'foo'
+            },
+            {
+              meta: {
+                date: 1996
+              },
+              name: 'bar'
+            },
+            {
+              meta: {
+                date: 2030
+              },
+              name: 'bear'
+            }
+          ]
+        },
+        '2019,1996,2030'
+      );
+
       finish(done);
     });
 

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -487,6 +487,29 @@
         '2019,1996,2030'
       );
 
+      expect(function() {
+        render(
+          '{{ items | join(",", "meta.date") }}',
+          {
+            items: [
+              {
+                meta: {
+                  date: 2019
+                }
+              },
+              {
+                date: {
+                  year: 2020
+                }
+              }
+            ]
+          },
+          {
+            throwOnUndefined: true
+          }
+        );
+      }).to.throwError(/join: attribute "meta\.date" resolved to undefined/);
+
       equal(
         '{{ ["<foo>", "<span>foo</span>"|safe]|join }}',
         '&lt;foo&gt;<span>foo</span>'


### PR DESCRIPTION
## Summary

Proposed change:

Improve join filter behaviour: respect `autoescape` and `throwOnUndefined`, add nested attribute support.

Closes #1308.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->