### PR TITLE
Add jinja-compat switch for precompile script

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -12,7 +12,7 @@ program
 
 program
   .name('precompile')
-  .usage('[-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-w|--wrapper <wrapper>] <path>')
+  .usage('[-f|--force] [-a|--filters <filters>] [-n|--name <name>] [-i|--include <regex>] [-x|--exclude <regex>] [-w|--wrapper <wrapper>] [-j|--jinja-compat] <path>')
   .arguments('<path>')
   .helpOption('-?, -h, --help', 'Display this help message')
   .option('-f, --force', 'Force compilation to continue on error')
@@ -21,6 +21,7 @@ program
   .option('-i, --include <regex>', 'Include a file or folder which match the regex but would otherwise be excluded. You can use this flag multiple times', concat, ['\\.html$', '\\.jinja$'])
   .option('-x, --exclude <regex>', 'Exclude a file or folder which match the regex but would otherwise be included. You can use this flag multiple times', concat, [])
   .option('-w, --wrapper <wrapper>', 'Load a external plugin to change the output format of the precompiled templates (for example, "-w custom" will load a module named "nunjucks-custom")')
+  .option('-j, --jinja-compat', 'Enable Jinja compatibility', false)
   .action(function (path) {
     cmdpath = path;
   })
@@ -46,6 +47,11 @@ lib.each([].concat(opts.filters).join(',').split(','), function (name) {
 
 if (opts.wrapper) {
   opts.wrapper = require('nunjucks-' + opts.wrapper).wrapper;
+}
+
+if (opts.jinjaCompat) {
+  var nunjucks = require('nunjucks');
+  nunjucks.installJinjaCompat();
 }
 
 console.log(precompile(cmdpath, {


### PR DESCRIPTION
See https://stackoverflow.com/a/45440732/6646912

## Summary

Proposed change:

Add `-j/--jinja-compat` switch to precompile script allowing to turn on the precompile mode.

## Checklist

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->