### PR TITLE
Move chokidar to peerDependencies and make it optional via peerDependenciesMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
   respect `throwOnUndefined` if sort attribute is undefined.
 * Add `base` arg to
   [`int` filter](https://mozilla.github.io/nunjucks/templating.html#int).
+* Move `chokidar` to `peerDependencies` and mark it `optional` in `peerDependenciesMeta`.
 
 3.2.2 (Jul 20 2020)
 -------------------

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Nunjucks
 
-  [![NPM Version][npm-image]][npm-url]
-  [![NPM Downloads][downloads-image]][downloads-url]
-  [![Linux Build][travis-image]][travis-url]
-  [![Windows Build][appveyor-image]][appveyor-url]
-  [![Test Codecov][codecov-image]][codecov-url]
+[![NPM Version][npm-image]][npm-url]
+[![NPM Downloads][downloads-image]][downloads-url]
+[![Linux Build][travis-image]][travis-url]
+[![Windows Build][appveyor-image]][appveyor-url]
+[![Test Codecov][codecov-image]][codecov-url]
 
 [Nunjucks](https://mozilla.github.io/nunjucks/) is a full featured
 templating engine for javascript. It is heavily inspired by
@@ -14,6 +14,10 @@ templating engine for javascript. It is heavily inspired by
 ## Installation
 
 `npm install nunjucks`
+
+To use the file watcher built-in to Nunjucks, Chokidar must be installed separately.
+
+`npm install nunjucks chokidar`
 
 (View the [CHANGELOG](https://github.com/mozilla/nunjucks/releases))
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,6 +25,12 @@ $ npm install nunjucks
 
 Once installed, simply use `require('nunjucks')` to load it.
 
+To use Nunjuck's built-in watch mode, Chokidar must be installed separately:
+
+```
+$ npm install nunjucks chokidar
+```
+
 Nunjucks supports all modern browsers and any version of Node.js
 [currently supported by the Node.js Foundation](https://github.com/nodejs/Release#release-schedule1).
 This includes the most recent version and all versions still in maintenance.

--- a/package.json
+++ b/package.json
@@ -55,8 +55,13 @@
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^3.10.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "chokidar": "^3.3.0"
+  },
+  "peerDependenciesMeta": {
+    "chokidar": {
+      "optional": true
+    }
   },
   "_moduleAliases": {
     "babel-register": "@babel/register"


### PR DESCRIPTION
## Summary

Proposed change:

This pull request implements the discussed solution to #1227 and moves `chokidar` from `optionalDependencies` (which never did what it aspired to do) to `peerDependencies`, and uses the recently implemented `peerDependenciesMeta` field to mark it as `optional`. This means for `npm` users using a version that supports `peerDependenciesMeta`, `chokidar` will have to be separately installed. This is in particularly relevant to the newest version of `npm` (v7), which installs `peerDependencies` by default unless the package is marked as `optional`.

Closes #1227.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->