### PR TITLE
Adding more specific documentation for `call`

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -395,6 +395,9 @@ Keyword/default arguments are available. See
 You can [import](#import) macros from other templates, allowing you to reuse
 them freely across your project.
 
+If you want to inject content in the macro's body (e.g. a block of HTML), 
+you might want to have a look at [call](#call).
+
 **Important note**: If you are using the asynchronous API, please be aware that
 you **cannot** do anything asynchronous inside macros. This is because macros
 are called like normal functions. In the future we may have a way to call a
@@ -635,15 +638,20 @@ content is available inside the macro as `caller()`.
 
 ```jinja
 {% macro add(x, y) %}
-{{ caller() }}: {{ x + y }}
+{{ caller() }}{{ x + y }}
 {% endmacro%}
 
 {% call add(1, 2) -%}
-The result is
+<span>Thanks for doing a calculation!</span>
+<span>The result is: </span>
 {%- endcall %}
 ```
 
-The above example would output "The result is: 3".
+The above example would output:
+```html
+<span>Thanks for doing a calculation!</span>
+<span>The result is: </span>3
+```
 
 ## Keyword Arguments
 


### PR DESCRIPTION
## Summary

Proposed change:
The documentation on call is a bit misleading, as it only injects a simple string (which could be injected as an argument as well). I think it makes more sense to demonstrate the usecase of injecting HTML into a macro. I therefore update the macro description with a hint to `call` and also update the `call` section to inject some HTML.

Please let me know what needs to change to get this merged. :-) 

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).