### PR TITLE
Documentation - Fix link to installJinjaCompat

### DIFF
--- a/docs/cn/faq.md
+++ b/docs/cn/faq.md
@@ -19,7 +19,7 @@ pageid: faq
 
 但是，如果你避免使用原生语言的特性（如 `{{ str.trim() }}`） 而完全使用模板的特性和过滤器，那么两者的模块可以兼容。
 
-Nunjucks 支持与 Jinja 兼容，查看 [installJinjaCompat](/api.html#installjinjacompat) 获取更多信息。
+Nunjucks 支持与 Jinja 兼容，查看 [installJinjaCompat](api.html#installjinjacompat) 获取更多信息。
 
 除此之外，nunjucks 还有一些未实现的功能：
 


### PR DESCRIPTION
The link was starting with `/`, which does not point to the correct page.

## Summary

Proposed change:

This change fixes the link to the installJinjaCompat page.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->