### PR TITLE
Fix `CallExtensionAsync` parse

### DIFF
--- a/nunjucks/src/transformer.js
+++ b/nunjucks/src/transformer.js
@@ -80,7 +80,7 @@ function _liftFilters(node, asyncFilters, prop) {
       return descNode;
     } else if ((descNode instanceof nodes.Filter &&
       lib.indexOf(asyncFilters, descNode.name.value) !== -1) ||
-      descNode instanceof nodes.CallExtensionAsync) {
+      descNode instanceof nodes.FilterAsync) {
       symbol = new nodes.Symbol(descNode.lineno,
         descNode.colno,
         gensym());

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -256,5 +256,49 @@
       expect(render('{{ "FOOBAR" is upper }}')).to.be('true');
       expect(render('{{ "Foobar" is upper }}')).to.be('false');
     });
+
+    it('should render async extensions inside macro', function(done) {
+      function AsyncExtension() {
+        this.tags = ['asyncextension'];
+
+        this.parse = function(parser, nodes, lexer) {
+          var tok, args, body, errorBody;
+          tok = parser.nextToken();
+          args = parser.parseSignature(null, true);
+          parser.advanceAfterBlockEnd(tok.value);
+          body = parser.parseUntilBlocks('error', 'endasyncextension');
+          errorBody = null;
+
+          if (parser.skipSymbol('error')) {
+            parser.skip(lexer.TOKEN_BLOCK_END);
+            errorBody = parser.parseUntilBlocks('endasyncextension');
+          }
+
+          parser.advanceAfterBlockEnd();
+
+          return new nodes.CallExtensionAsync(this, 'run', args, [body, errorBody]);
+        };
+
+        this.run = function(context, url, body, errorBody, callback) {
+          callback(null, 'Foo async extension content');
+        };
+      }
+
+      render(
+        '{% macro wrap() %}{{ caller() }}{% endmacro %}' +
+        '{% call wrap() %}{% asyncextension "foobar" %}1{% error %}2{% endasyncextension %}{% endcall %}',
+        {},
+        {
+          extensions: {
+            AsyncExtension: new AsyncExtension()
+          }
+        },
+        function(err, str) {
+          expect(str).to.be('Foo async extension content');
+
+          done();
+        }
+      );
+    });
   });
 }());


### PR DESCRIPTION
## Summary

Proposed change:

Fix parsing of async extensions. It's treated as filter now, and looks like old typo.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->