### PR TITLE
docs: Fix &gt; in autoescaping docs

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -855,7 +855,7 @@ be escaped for safe output. To manually mark output as safe, use the `safe`
 filter. Nunjucks will not escape this output.
 
 ```jinja
-{{ foo }}           // &lt;span%gt;
+{{ foo }}           // &lt;span&gt;
 {{ foo | safe }}    // <span>
 ```
 


### PR DESCRIPTION
## Summary

Proposed change:

Fixes doc typo:

```diff
-%gt;
+&gt;
```
