### PR TITLE
Fix typo in `replace` example

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1528,7 +1528,7 @@ and replacing them surrounding an item:
 **Input**
 
 ```jinja
-{% set letters = aaabbbccc%}
+{% set letters = "aaabbbccc" %}
 {{ letters | replace("", ".") }}
 ```
 


### PR DESCRIPTION
## Summary

Quote the string `aaabbbccc` so that it is treated as a string rather than a variable name.

Add a space before the closing delimiter to match the format used elsewhere on the page.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] ~~[*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.~~ N/A
* [ ] ~~[*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).~~ N/A