### PR TITLE
Typo in API documentation #1406

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -437,8 +437,7 @@ templates live, and it defaults to the current working directory.
 
 **opts** is an object with the following optional properties:
 
-* **watch** - if `true`, the system will automatically update templates. To use watch, make sure optional dependency *chokidar* is installed.
-  when they are changed on the filesystem
+* **watch** - if `true`, the system will automatically update templates when they are changed on the filesystem. To use watch, make sure optional dependency *chokidar* is installed.
 * **noCache** - if `true`, the system will avoid using a cache and templates
   will be recompiled every single time
 


### PR DESCRIPTION
## Summary

Proposed change:

on page: https://mozilla.github.io/nunjucks/api.html

the system will automatically update templates. To use watch, make sure optional dependency chokidar is installed. when they are changed on the filesystem

change to:

the system will automatically update templates when they are changed on the filesystem. To use watch, make sure optional dependency chokidar is installed.



Closes #1406.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->