### PR TITLE
fix: html encode backslashes if used with escape filter or autoescape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+3.2.4 (unreleased)
+------------------
+
+* HTML encode backslashes when expressions are passed through the escape
+  filter (including when this is done automatically with autoescape). Merge
+  of [#1427](https://github.com/mozilla/nunjucks/pull/1427).
+
 3.2.3 (Feb 15 2021)
 -------------------
 

--- a/nunjucks/src/lib.js
+++ b/nunjucks/src/lib.js
@@ -8,10 +8,11 @@ var escapeMap = {
   '"': '&quot;',
   '\'': '&#39;',
   '<': '&lt;',
-  '>': '&gt;'
+  '>': '&gt;',
+  '\\': '&#92;',
 };
 
-var escapeRegex = /[&"'<>]/g;
+var escapeRegex = /[&"'<>\\]/g;
 
 var exports = module.exports = {};
 

--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1976,6 +1976,16 @@
       finish(done);
     });
 
+    it('should autoescape backslashes', function(done) {
+      equal(
+        '{{ foo }}',
+        { foo: 'foo \\\' bar' },
+        { autoescape: true },
+        'foo &#92;&#39; bar');
+
+      finish(done);
+    });
+
     it('should not autoescape when extension set false', function(done) {
       function TestExtension() {
         // jshint validthis: true
@@ -2031,7 +2041,7 @@
     });
 
     it('should render regexs', function(done) {
-      equal('{{ r/name [0-9] \\// }}',
+      equal('{{ r/name [0-9] \\// }}', {}, { autoescape: false },
         '/name [0-9] \\//');
 
       equal('{{ r/x/gi }}',

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -108,9 +108,9 @@
 
     it('escape', function() {
       equal(
-        '{{ "<html>" | escape }}', {},
+        '{{ "<html>\\\\" | escape }}', {},
         { autoescape: false },
-        '&lt;html&gt;');
+        '&lt;html&gt;&#92;');
     });
 
     it('escape skip safe', function() {


### PR DESCRIPTION
Backslashes should be html encoded when present in expressions that are passed to the escape filter (including when this happens automatically with autoescape)