### PR TITLE
Fix incorrect PR number in changelog for 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 
 * HTML encode backslashes when expressions are passed through the escape
   filter (including when this is done automatically with autoescape). Merge
-  of [#1427](https://github.com/mozilla/nunjucks/pull/1427).
+  of [#1437](https://github.com/mozilla/nunjucks/pull/1437).
 
 3.2.3 (Feb 15 2021)
 -------------------


### PR DESCRIPTION
## Summary

Proposed change:

Link to the correct PR (#1437) in the changelog entry for 3.2.4

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).