### PR TITLE
docs: add example how to set a var from a file's content using includ…

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -538,6 +538,16 @@ an `include` is _not_ a pre-processor that pulls the included template code
 into the including template before rendering; instead, it fires off a separate
 render of the included template, and the results of that render are included.
 
+Set var from file
+You can also create a var from a file's content. For example a .json file, which you can then stringify using dump.
+```jinja
+{% set fileAsVar %}
+     {% include 'example.json' %}
+{% endset %}
+
+{{- fileAsVar | dump -}}
+```
+
 ### import
 
 `import` loads a different template and allows you to access its exported


### PR DESCRIPTION
…e in a block

I racked my brain around this for days, until I found this in some outside code example. I think it should be clearer that outside files can be included and transformed using a var, especially since the expected idiomatic approach does not work:

{% set example_output = include 'example.json' % }

## Summary

Proposed change:

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

Closes # .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->