### PR TITLE
Add "When Using Webpack..." to "Getting Started"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,45 @@ to be changed. This makes it easy to use the same code in
 development and production, while using precompiled templates in
 production.
 
+## When Using Webpack...
+
+```
+$ npm install html-bundler-webpack-plugin nunjucks --save-dev
+```
+
+The [HTML bundler plugin for Webpack](https://github.com/webdiscus/html-bundler-webpack-plugin) compiles [nunjucks templates](https://github.com/webdiscus/html-bundler-webpack-plugin#using-template-nunjucks) into static HTML files.
+
+Configurate the _webpack.config.js_ for using nunjucks tempaltes:
+```js
+const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    new HtmlBundlerPlugin({
+      entry: {
+        // define templates as entriypoints here, e.g.:
+        index: 'src/views/pages/index.njk', // output to dist/index.html
+        'news/sport': 'src/views/pages/news/sport/index.njk', // output to dist/news/sport.html
+      },
+      preprocessor: 'nunjucks', // use nunjucks templating engine
+      preprocessorOptions: {
+        // paths to templates
+        views: [
+          'src/views/includes',
+          'src/views/partials',
+        ],
+        jinjaCompatibility: false, // installs support for Jinja compatibility, defaults 'false'
+        // define nunjucks options here, e.g.:
+        autoescape: true,
+        // ...
+      },
+    }),
+  ],
+};
+```
+
+For all available options, see the nunjucks [API configure](https://mozilla.github.io/nunjucks/api.html#configure).
+
 ## More Information
 
 That's only the tip of the iceberg. See [API](api.html) for API docs


### PR DESCRIPTION
## Summary

Proposed change:

Added information to the  [Getting Started](https://mozilla.github.io/nunjucks/getting-started.html) site about using Webpack to compile nunjucks templates.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->