### PR TITLE
fix in operator

### DIFF
--- a/nunjucks/src/lib.js
+++ b/nunjucks/src/lib.js
@@ -384,7 +384,9 @@ function extend(obj1, obj2) {
 exports._assign = exports.extend = extend;
 
 function inOperator(key, val) {
-  if (isArray(val) || isString(val)) {
+  if (typeof val === 'undefined') {
+    return false;
+  } else if (isArray(val) || isString(val)) {
     return val.indexOf(key) !== -1;
   } else if (isObject(val)) {
     return key in val;


### PR DESCRIPTION
## Summary

When using the `in` operator inside a template literal, if the object is null, compiler will fail.

For example: 
`{{ 'yes' if myOption in preferences else 'no' }}` fails to render if `preferences` is not in context map.

In Python's Jinja2 render, it is possible to setup the compiler to make this render to `false`.
I would expect this not to fail if `throwOnUndefined` is set to false. If this is not the expected behavior, would like to hear what would be the option to support this.

Also would like to add a test for this but I am not sure what would be the correct location.

This PR fixes the compiler issue.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->