### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Contributions are always welcome! Before you submit an issue or pull request, pl
 [npm-url]: https://npmjs.org/package/nunjucks
 [downloads-image]: https://img.shields.io/npm/dm/nunjucks.svg
 [downloads-url]: https://npmjs.org/package/nunjucks
-[github-actions-image]: https://img.shields.io/github/workflow/status/mozilla/nunjucks/Tests/master.svg?label=linux
+[github-actions-image]: https://img.shields.io/github/actions/workflow/status/mozilla/nunjucks/tests.yml?branch=master&label=linux
 [github-actions-url]: https://github.com/mozilla/nunjucks/actions
 [appveyor-image]: https://img.shields.io/appveyor/ci/fdintino/nunjucks/master.svg?label=windows
 [appveyor-url]: https://ci.appveyor.com/project/fdintino/nunjucks


### PR DESCRIPTION
## Summary

Proposed change:

fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [ ] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->