### PR TITLE
GraalJS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.2.4 (Jan 15 2024)
+------------------
+
+* Add support for running nunjucks in GraalJS environments.
+
 3.2.4 (Apr 13 2023)
 ------------------
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,17 @@ Grab [nunjucks.js](files/nunjucks.js) ([min](files/nunjucks.min.js)) for the ful
 [nunjucks-slim.js](files/nunjucks-slim.js) ([min](files/nunjucks-slim.min.js)) for the slim version
 which only works with precompiled templates.
 
+## When in a GraalJS environment...
+
+Grab [nunjucks.js](files/nunjucks.js) ([min](files/nunjucks.min.js)) and add this as a script to an
+instance of the GraalJS Script Engine. You will need to ensure the script engine has the following enabled:
+* Allow IO
+* Allow Experimental Options
+* The `js.shell` option
+
+Depending on your setup, you may need to add a polyfill script to be loaded before nunjucks which adds a 
+global `window` object.
+
 ### Which file should you use?
 
 * Use **nunjucks.js** to dynamically load templates, auto-reload

--- a/nunjucks/src/environment.js
+++ b/nunjucks/src/environment.js
@@ -16,21 +16,15 @@ const expressApp = require('./express-app');
 // If the user is using the async API, *always* call it
 // asynchronously even if the template was synchronous.
 function callbackAsap(cb, err, res) {
-
   // Check if running in graaljs
-  if (typeof Graal != 'undefined') {
-
+  if (typeof Graal !== 'undefined') {
     // Callback immediately.
     cb(err, res);
-
   } else {
-
     asap(() => {
       cb(err, res);
     });
-
   }
-
 }
 
 /**

--- a/nunjucks/src/environment.js
+++ b/nunjucks/src/environment.js
@@ -16,9 +16,21 @@ const expressApp = require('./express-app');
 // If the user is using the async API, *always* call it
 // asynchronously even if the template was synchronous.
 function callbackAsap(cb, err, res) {
-  asap(() => {
+
+  // Check if running in graaljs
+  if (typeof Graal != 'undefined') {
+
+    // Callback immediately.
     cb(err, res);
-  });
+
+  } else {
+
+    asap(() => {
+      cb(err, res);
+    });
+
+  }
+
 }
 
 /**

--- a/nunjucks/src/web-loaders.js
+++ b/nunjucks/src/web-loaders.js
@@ -24,7 +24,23 @@ class WebLoader extends Loader {
   }
 
   resolve(from, to) {
-    throw new Error('relative templates not support in the browser yet');
+    var stack;
+    var parts;
+    if (typeof Graal !== 'undefined') {
+      stack = from.split('/');
+      parts = to.split('/');
+      stack.pop();
+      for (let i = 0; i < parts.length; i++) {
+        if (parts[i] === '..') {
+          stack.pop();
+        } else if (parts[i] !== '.') {
+          stack.push(parts[i]);
+        }
+      }
+      return stack.join('/');
+    } else {
+      throw new Error('relative templates not support in the browser yet');
+    }
   }
 
   getSource(name, cb) {

--- a/nunjucks/src/web-loaders.js
+++ b/nunjucks/src/web-loaders.js
@@ -30,7 +30,8 @@ class WebLoader extends Loader {
   getSource(name, cb) {
     var useCache = this.useCache;
     var result;
-    var emitResult = function() {
+    var content;
+    var emitResult = (src) => {
       result = {
         src: src,
         path: name,
@@ -43,17 +44,11 @@ class WebLoader extends Loader {
     };
 
     // Check if running in graaljs.
-    if (typeof Graal != 'undefined') {
-
+    if (typeof Graal !== 'undefined') {
       // Use graal's read(file) to get contents from another file.
-      var path = _this2.baseURL + "/" + name;
-      var src = read(path);
-
-      // Skip fetch.
-      emitResult();
-
+      content = read(this.baseURL + '/' + name); // eslint-disable-line func-names, no-undef
+      emitResult(content);
     } else {
-
       this.fetch(this.baseURL + '/' + name, (err, src) => {
         if (err) {
           if (cb) {
@@ -64,10 +59,9 @@ class WebLoader extends Loader {
             throw err.content;
           }
         } else {
-          emitResult();
+          emitResult(content);
         }
       });
-
     }
 
     // if this WebLoader isn't running asynchronously, the

--- a/nunjucks/src/web-loaders.js
+++ b/nunjucks/src/web-loaders.js
@@ -30,7 +30,6 @@ class WebLoader extends Loader {
   getSource(name, cb) {
     var useCache = this.useCache;
     var result;
-    var content;
     var emitResult = (src) => {
       result = {
         src: src,
@@ -46,8 +45,7 @@ class WebLoader extends Loader {
     // Check if running in graaljs.
     if (typeof Graal !== 'undefined') {
       // Use graal's read(file) to get contents from another file.
-      content = read(this.baseURL + '/' + name); // eslint-disable-line func-names, no-undef
-      emitResult(content);
+      emitResult(read(this.baseURL + '/' + name)); // eslint-disable-line func-names, no-undef
     } else {
       this.fetch(this.baseURL + '/' + name, (err, src) => {
         if (err) {
@@ -59,7 +57,7 @@ class WebLoader extends Loader {
             throw err.content;
           }
         } else {
-          emitResult(content);
+          emitResult(src);
         }
       });
     }

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -94,24 +94,22 @@
         loader.getSource('simple-base.njk');
       });
 
-      it('should have default opts for WebLoader in graaljs', function(done) {
-        var loader;
+      it('should have default opts for WebLoader in graaljs', function() {
+        var env;
+        var parent;
 
-        if (typeof window === 'undefined') {
+        if (typeof global === 'undefined') {
           this.skip();
         }
 
-        window.Graal = true;
-        window.read = (src) => src;
+        global.Graal = true;
+        global.read = (src) => 'Hello World';
 
-        loader = new WebLoader(templatesPath);
-
-        loader.on('load', function(name, source) {
-          expect(name).to.equal('simple-base.njk');
-          done();
-        });
-
-        loader.getTemplate('simple-base.njk');
+        env = new Environment(new WebLoader(templatesPath));
+        parent = env.getTemplate('fake.njk');
+        expect(parent.render()).to.be('Hello World');
+        delete global.Graal;
+        delete global.read;
       });
     });
 

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -108,8 +108,26 @@
         env = new Environment(new WebLoader(templatesPath));
         parent = env.getTemplate('fake.njk');
         expect(parent.render()).to.be('Hello World');
+
         delete global.Graal;
         delete global.read;
+      });
+
+      it('should resolve in graaljs', function() {
+        var loader;
+        var resolved;
+
+        if (typeof global === 'undefined') {
+          this.skip();
+        }
+
+        global.Graal = true;
+
+        loader = new WebLoader(templatesPath);
+        resolved = loader.resolve('components/fragments/origin.njk', './../fake.njk');
+        expect(resolved).to.be('components/fake.njk');
+
+        delete global.Graal;
       });
     });
 

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -93,6 +93,26 @@
 
         loader.getSource('simple-base.njk');
       });
+
+      it('should have default opts for WebLoader in graaljs', function(done) {
+        var loader;
+
+        if (typeof window === 'undefined') {
+          this.skip();
+        }
+
+        window.Graal = true;
+        window.read = (src) => src;
+
+        loader = new WebLoader(templatesPath);
+
+        loader.on('load', function(name, source) {
+          expect(name).to.equal('simple-base.njk');
+          done();
+        });
+
+        loader.getTemplate('simple-base.njk');
+      });
     });
 
     if (typeof FileSystemLoader !== 'undefined') {


### PR DESCRIPTION
## Summary

Proposed change:

GraalJS is an environment which allows JavaScript to be run in a VM controlled by other languages such as Java. Unfortunately, the environment is missing several global functions often expected in scripts written for Nodejs or browser environments. 

A few small changes allow for nunjucks to check if it is being run in a GraalJS environment and replace calls to the non-existant functions with the Graal alternatives. This allows nunjucks to run in a Graal environment without issue, opening up the possibility of using the framework with more languages.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).