### PR TITLE
docs: fix: put string literal within double quotes

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1528,7 +1528,7 @@ and replacing them surrounding an item:
 **Input**
 
 ```jinja
-{% set letters = aaabbbccc%}
+{% set letters = "aaabbbccc" %}
 {{ letters | replace("", ".") }}
 ```
 


### PR DESCRIPTION
## Summary

Proposed change:

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

This PR fixes a bug / issue in the docs site. The bug / issue is in one of the exampels in the `Templating` section under `replace` section

Closes #1470 


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->