### PR TITLE
Issue #1467: Changed link to vim syntax highlighting.

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -39,7 +39,7 @@ include recognition of the `.njk` extension.
 Plugins are available in various editors to support the `jinja` syntax highlighting of Nunjucks.
 
 * atom <https://github.com/alohaas/language-nunjucks>
-* vim <https://github.com/niftylettuce/vim-jinja>
+* vim <https://github.com/lepture/vim-jinja>
 * brackets <https://github.com/axelboc/nunjucks-brackets>
 * sublime <https://github.com/mogga/sublime-nunjucks/blob/master/Nunjucks.tmLanguage>
 * emacs <http://web-mode.org>


### PR DESCRIPTION
Updated link to vim syntax highlighting to no longer link to outdated repository.

closes #1467.

## Summary

Proposed change:

The linked repository niftylettuce/vim-jinja seems to no longer exist. According to @ernstki 's recommendation, I changed the link to lepture/vim-jinja.

Closes # .


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

*Comment: Since the proposed change affects documentation only, I did not include tests yet - are there tests for documentation?*

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->