### PR TITLE
Clarify title filter behavior in Templating docs

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1809,7 +1809,7 @@ Output the sum of items in the array:
 
 ### title
 
-Make the first letter of the string uppercase:
+Make the first letter of each word in the string uppercase:
 
 **Input**
 


### PR DESCRIPTION


## Summary

Proposed change:

<!--
	Please replace this with a human-friendly description of your proposed change.
	* If you have multiple changes, try to split them into separate PRs.
	* If this change closes an issue, please write "Closes #{number}".
-->

This PR updates the Templating docs to correct the explanation of the behavior of `title`. Previously, the docs indicate that only the first character in a string will be upper-cased but the example (and behavior as I've just tested) is that `title` will upper-case each word in a string, not just the first character. For avoidance of doubt, https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.title clearly sets out the intended behavior.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/mozilla/nunjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/mozilla/nunjucks/tree/master/docs/) is added / updated to describe proposed change.
* [ ] [*Tests*](https://github.com/mozilla/nunjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->